### PR TITLE
Synchronize frame payloads

### DIFF
--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -3,17 +3,19 @@ import asyncio
 import logging
 import multiprocessing
 import pandas as pd
+from queue import Queue
 from pathlib import Path
 import cv2
 
 from skellycam.detection.detect_cameras import detect_cameras
 from skellycam.opencv.group.camera_group import CameraGroup
 from skellycam.system.environment.default_paths import default_session_folder_path
+from skellycam.opencv.group.synchronizer import Synchronizer
 
 logger = logging.getLogger(__name__)
 
 
-async def show_all_cameras_in_cv2_windows(camera_ids_list: list = None):
+async def show_synched_frames(camera_ids_list: list = None):
 
     if camera_ids_list is None:
         camera_ids_list = [0]
@@ -22,38 +24,79 @@ async def show_all_cameras_in_cv2_windows(camera_ids_list: list = None):
     camera_group.start()
     should_continue = True
 
+
+    syncr = Synchronizer(camera_ids_list)
+
+    bundle_q = Queue()
+    syncr.subscribe_to_bundle(bundle_q)
+     
+    bundle_index = 0
+    bundle_data = {"Bundle":[],
+                   "Port_0_Time":[],
+                   "Port_1_Time":[],
+                   "Port_2_Time":[]}
+
     frame_times = {"port": [],
                    "frame_index": [],
                    "frame_time": [] }
 
+
     for p in multiprocessing.active_children():
         print(f"before big frame loop - found child process: {p}")
 
-    while should_continue:
+    # wait for all cameras to begin delivering frames before trying to synchronize
+    payload_count = 0
+    while payload_count < len(camera_ids_list):
+        payload_count = 0
         latest_frame_payloads = camera_group.latest_frames()
         for cam_id, frame_payload in latest_frame_payloads.items():
             if frame_payload is not None:
-                cv2.imshow(f"Camera {cam_id} - Press ESC to quit", frame_payload.image)
-                frame_times["port"].append(frame_payload.camera_id)
+                payload_count+=1
+                
+    print("------------------------------------------------------------------------------")
+
+    while should_continue:
+        latest_frame_payloads = camera_group.latest_frames()
+        
+        for cam_id, frame_payload in latest_frame_payloads.items():
+            if frame_payload is not None:
+                syncr.add_frame_payload(frame_payload)
+                frame_times["port"].append(frame_payload.camera_id)        
                 frame_times["frame_index"].append(frame_payload.frame_number)
                 frame_times["frame_time"].append(frame_payload.timestamp_ns)
-        
 
+        if not bundle_q.empty():
+            new_bundle = bundle_q.get()
 
+            bundle_data["Bundle"].append(bundle_index)
+            bundle_index += 1
+
+            for port, frame_data in new_bundle.items():
+                if frame_data:
+                    cv2.imshow(f"Port {port}", frame_data["frame"])
+                    bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
+                else:
+                    bundle_data[f"Port_{port}_Time"].append("dropped")     
 
         if cv2.waitKey(1) == 27:
             logger.info(f"ESC key pressed - shutting down")
             cv2.destroyAllWindows()
             should_continue = False
 
+
     camera_group.close()
 
     frame_times = pd.DataFrame(frame_times)
     frame_times.to_csv(Path(default_session_folder_path(create_folder=True),"frame_times.csv"))
 
+    bundle_data = pd.DataFrame(bundle_data)
+    bundle_data.to_csv(Path(default_session_folder_path(create_folder=True),"bundle_data.csv"))
+    
+
 if __name__ == "__main__":
     found_camera_response = detect_cameras()
     camera_ids_list_in = found_camera_response.cameras_found_list
-    asyncio.run(show_all_cameras_in_cv2_windows(camera_ids_list_in))
+    
+    asyncio.run(show_synched_frames(camera_ids_list_in))
 
     print("done!")

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 import multiprocessing
 import pandas as pd
 from queue import Queue
@@ -39,20 +40,6 @@ def show_synched_frames(camera_ids_list: list = None):
 
     for p in multiprocessing.active_children():
         print(f"before big frame loop - found child process: {p}")
-
-    # wait for all cameras to begin delivering frames before trying to synchronize
-    # this takes awhile and appears to have some false reads before things really get going
-    payload_count = 0
-    while payload_count < len(camera_ids_list):
-        payload_count = 0
-        latest_frame_payloads = camera_group.latest_frames()
-        for cam_id, frame_payload in latest_frame_payloads.items():
-            if frame_payload is not None:
-                payload_count += 1
-
-    print(
-        "------------------------------------------------------------------------------"
-    )
 
     while should_continue:
         latest_frame_payloads = camera_group.latest_frames()

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -33,8 +33,6 @@ def show_synched_frames(camera_ids_list: list = None):
 
     # will be receiving a bundle of synched frames via queue
     syncr = Synchronizer(camera_ids_list)
-    bundle_q = Queue()
-    syncr.subscribe_to_bundle(bundle_q)
 
     # bundle data and frame times are just for summary reporting...saved to csv in default session folder path
     bundle_index = 0
@@ -62,11 +60,10 @@ def show_synched_frames(camera_ids_list: list = None):
                 frame_times["skellycam_index"].append(frame_payload.frame_number)
                 frame_times["frame_time"].append(frame_payload.timestamp_ns)
 
-        if not bundle_q.empty():
+        if not syncr.bundle_out_q.empty():
 
-            # when a synched bundle is available, the synchronizer pushes it out to subscribed queues
-            # if there is something on the queue, grab it...
-            new_bundle = bundle_q.get()
+            # if there is something on the synched bundle queue, grab it...
+            new_bundle = syncr.bundle_out_q.get()
 
             # the section below is just for display and summary output
             bundle_data["Bundle"].append(bundle_index)

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -1,11 +1,14 @@
+
 import asyncio
 import logging
 import multiprocessing
-
+import pandas as pd
+from pathlib import Path
 import cv2
 
 from skellycam.detection.detect_cameras import detect_cameras
 from skellycam.opencv.group.camera_group import CameraGroup
+from skellycam.system.environment.default_paths import default_session_folder_path
 
 logger = logging.getLogger(__name__)
 
@@ -19,16 +22,25 @@ async def show_all_cameras_in_cv2_windows(camera_ids_list: list = None):
     camera_group.start()
     should_continue = True
 
+    frame_times = {"port": [],
+                   "frame_index": [],
+                   "frame_time": [] }
+
     for p in multiprocessing.active_children():
         print(f"before big frame loop - found child process: {p}")
 
     while should_continue:
         latest_frame_payloads = camera_group.latest_frames()
-        
-        print(time.time())
         for cam_id, frame_payload in latest_frame_payloads.items():
             if frame_payload is not None:
                 cv2.imshow(f"Camera {cam_id} - Press ESC to quit", frame_payload.image)
+                frame_times["port"].append(frame_payload.camera_id)
+                frame_times["frame_index"].append(frame_payload.frame_number)
+                frame_times["frame_time"].append(frame_payload.timestamp_ns)
+        
+
+
+
         if cv2.waitKey(1) == 27:
             logger.info(f"ESC key pressed - shutting down")
             cv2.destroyAllWindows()
@@ -36,6 +48,8 @@ async def show_all_cameras_in_cv2_windows(camera_ids_list: list = None):
 
     camera_group.close()
 
+    frame_times = pd.DataFrame(frame_times)
+    frame_times.to_csv(Path(default_session_folder_path(create_folder=True),"frame_times.csv"))
 
 if __name__ == "__main__":
     found_camera_response = detect_cameras()

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -1,0 +1,45 @@
+import asyncio
+import logging
+import multiprocessing
+
+import cv2
+
+from skellycam.detection.detect_cameras import detect_cameras
+from skellycam.opencv.group.camera_group import CameraGroup
+
+logger = logging.getLogger(__name__)
+
+
+async def show_all_cameras_in_cv2_windows(camera_ids_list: list = None):
+
+    if camera_ids_list is None:
+        camera_ids_list = [0]
+
+    camera_group = CameraGroup(camera_ids_list)
+    camera_group.start()
+    should_continue = True
+
+    for p in multiprocessing.active_children():
+        print(f"before big frame loop - found child process: {p}")
+
+    while should_continue:
+        latest_frame_payloads = camera_group.latest_frames()
+        
+        print(time.time())
+        for cam_id, frame_payload in latest_frame_payloads.items():
+            if frame_payload is not None:
+                cv2.imshow(f"Camera {cam_id} - Press ESC to quit", frame_payload.image)
+        if cv2.waitKey(1) == 27:
+            logger.info(f"ESC key pressed - shutting down")
+            cv2.destroyAllWindows()
+            should_continue = False
+
+    camera_group.close()
+
+
+if __name__ == "__main__":
+    found_camera_response = detect_cameras()
+    camera_ids_list_in = found_camera_response.cameras_found_list
+    asyncio.run(show_all_cameras_in_cv2_windows(camera_ids_list_in))
+
+    print("done!")

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -1,3 +1,10 @@
+# This module provides an example for how the Synchronizer class can interface with the 
+# CameraGroup class in order to produce synchronized frame bundles in (almost) real-time.
+
+# Much of this code is just overhead to produced two .csv files in the default session folder:
+#   `frame_times.csv`: the actual ports/frame times as they came in from the camera group. 
+#   `bundle_data.csv`: shows frame_times associated with the ports in each bundle, making dropped frames explicit
+
 import asyncio
 import logging
 import time
@@ -66,7 +73,9 @@ def show_synched_frames(camera_ids_list: list = None):
             bundle_index += 1
             for port, frame_data in new_bundle.items():
                 if frame_data:
-                    cv2.imshow(f"Port {port}", frame_data["frame"]) #display frames just to make sure it's working
+                    cv2.imshow(
+                        f"Port {port}", frame_data["frame"]
+                    )  # display frames just to make sure it's working
                     bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
                 else:
                     bundle_data[f"Port_{port}_Time"].append("dropped")
@@ -78,12 +87,13 @@ def show_synched_frames(camera_ids_list: list = None):
 
     camera_group.close()
 
-    # export summary output
+    # export summary frame_time output
     frame_times = pd.DataFrame(frame_times)
     frame_times.to_csv(
         Path(default_session_folder_path(create_folder=True), "frame_times.csv")
     )
 
+    # export summary bundle_data output
     bundle_data = pd.DataFrame(bundle_data)
     bundle_data.to_csv(
         Path(default_session_folder_path(create_folder=True), "bundle_data.csv")
@@ -94,7 +104,6 @@ if __name__ == "__main__":
     found_camera_response = detect_cameras()
     camera_ids_list_in = found_camera_response.cameras_found_list
 
-    # asyncio.run(show_synched_frames(camera_ids_list_in))
     show_synched_frames(camera_ids_list_in)
 
     print("done!")

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -31,10 +31,10 @@ async def show_synched_frames(camera_ids_list: list = None):
     syncr.subscribe_to_bundle(bundle_q)
      
     bundle_index = 0
-    bundle_data = {"Bundle":[],
-                   "Port_0_Time":[],
-                   "Port_1_Time":[],
-                   "Port_2_Time":[]}
+    bundle_data = {"Bundle":[]}
+
+    for port in camera_ids_list:
+        bundle_data[f"Port_{port}_Time"] = []
 
     frame_times = {"port": [],
                    "frame_index": [],

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -36,7 +36,7 @@ def show_synched_frames(camera_ids_list: list = None):
     for port in camera_ids_list:
         bundle_data[f"Port_{port}_Time"] = []
 
-    frame_times = {"port": [], "frame_index": [], "frame_time": []}
+    frame_times = {"port": [], "skellycam_index": [], "frame_time": []}
 
     for p in multiprocessing.active_children():
         print(f"before big frame loop - found child process: {p}")
@@ -52,7 +52,7 @@ def show_synched_frames(camera_ids_list: list = None):
 
                 # dictionary below is just to create summary output
                 frame_times["port"].append(frame_payload.camera_id)
-                frame_times["frame_index"].append(frame_payload.frame_number)
+                frame_times["skellycam_index"].append(frame_payload.frame_number)
                 frame_times["frame_time"].append(frame_payload.timestamp_ns)
 
         if not bundle_q.empty():

--- a/skellycam/examples/synchronize_frame_payloads.py
+++ b/skellycam/examples/synchronize_frame_payloads.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import logging
 import multiprocessing
@@ -24,22 +23,19 @@ async def show_synched_frames(camera_ids_list: list = None):
     camera_group.start()
     should_continue = True
 
-
+    # will be receiving a bundle of synched frames via queue
     syncr = Synchronizer(camera_ids_list)
-
     bundle_q = Queue()
     syncr.subscribe_to_bundle(bundle_q)
-     
+
+    # bundle data and frame times are just for summary reporting...saved to csv in default session folder path
     bundle_index = 0
-    bundle_data = {"Bundle":[]}
+    bundle_data = {"Bundle": []}
 
     for port in camera_ids_list:
         bundle_data[f"Port_{port}_Time"] = []
 
-    frame_times = {"port": [],
-                   "frame_index": [],
-                   "frame_time": [] }
-
+    frame_times = {"port": [], "frame_index": [], "frame_time": []}
 
     for p in multiprocessing.active_children():
         print(f"before big frame loop - found child process: {p}")
@@ -51,52 +47,65 @@ async def show_synched_frames(camera_ids_list: list = None):
         latest_frame_payloads = camera_group.latest_frames()
         for cam_id, frame_payload in latest_frame_payloads.items():
             if frame_payload is not None:
-                payload_count+=1
-                
-    print("------------------------------------------------------------------------------")
+                payload_count += 1
+
+    print(
+        "------------------------------------------------------------------------------"
+    )
 
     while should_continue:
         latest_frame_payloads = camera_group.latest_frames()
-        
+
         for cam_id, frame_payload in latest_frame_payloads.items():
             if frame_payload is not None:
-                syncr.add_frame_payload(frame_payload)
-                frame_times["port"].append(frame_payload.camera_id)        
+                syncr.add_frame_payload(
+                    frame_payload
+                )  # the line that does something; give synchronizer a payload
+
+                # dictionary below is just to create summary output
+                frame_times["port"].append(frame_payload.camera_id)
                 frame_times["frame_index"].append(frame_payload.frame_number)
                 frame_times["frame_time"].append(frame_payload.timestamp_ns)
 
         if not bundle_q.empty():
+            # when a synched bundle is available, the synchronizer pushes it out to subscribers
+
             new_bundle = bundle_q.get()
 
             bundle_data["Bundle"].append(bundle_index)
             bundle_index += 1
 
+            # the block below is just for display and summary output
             for port, frame_data in new_bundle.items():
                 if frame_data:
                     cv2.imshow(f"Port {port}", frame_data["frame"])
                     bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
                 else:
-                    bundle_data[f"Port_{port}_Time"].append("dropped")     
+                    bundle_data[f"Port_{port}_Time"].append("dropped")
 
         if cv2.waitKey(1) == 27:
             logger.info(f"ESC key pressed - shutting down")
             cv2.destroyAllWindows()
             should_continue = False
 
-
     camera_group.close()
 
+    # export summary output
     frame_times = pd.DataFrame(frame_times)
-    frame_times.to_csv(Path(default_session_folder_path(create_folder=True),"frame_times.csv"))
+    frame_times.to_csv(
+        Path(default_session_folder_path(create_folder=True), "frame_times.csv")
+    )
 
     bundle_data = pd.DataFrame(bundle_data)
-    bundle_data.to_csv(Path(default_session_folder_path(create_folder=True),"bundle_data.csv"))
-    
+    bundle_data.to_csv(
+        Path(default_session_folder_path(create_folder=True), "bundle_data.csv")
+    )
+
 
 if __name__ == "__main__":
     found_camera_response = detect_cameras()
     camera_ids_list_in = found_camera_response.cameras_found_list
-    
+
     asyncio.run(show_synched_frames(camera_ids_list_in))
 
     print("done!")

--- a/skellycam/opencv/group/synchronizer.py
+++ b/skellycam/opencv/group/synchronizer.py
@@ -71,21 +71,21 @@ class Synchronizer:
 
         # once frames actually start coming in, need to set it to the correct
         # starting point
-        if self.port_current_frame[payload.camera_id] == 0:
-            self.port_current_frame[payload.camera_id] = payload.frame_number
-            self.port_frame_count[payload.camera_id] = payload.frame_number
+        # if self.port_current_frame[payload.camera_id] == 0:
+        #     self.port_current_frame[payload.camera_id] = payload.frame_number
+        #     self.port_frame_count[payload.camera_id] = payload.frame_number
 
         # print(
         #     f"{payload.camera_id}: {payload.frame_number} @ {payload.timestamp_ns/(10^9)}"
         # )
-        key = f"{payload.camera_id}_{payload.frame_number}"
+        frame_index = self.port_frame_count[payload.camera_id]
+        key = f"{payload.camera_id}_{frame_index}"
         self.frame_data[key] = {
             "port": payload.camera_id,
             "frame": payload.image,
-            "frame_index": self.port_frame_count[payload.camera_id],
+            "frame_index": frame_index,
             "frame_time": payload.timestamp_ns,
         }
-
         self.port_frame_count[payload.camera_id] += 1
 
     # get minimum value of frame_time for next layer
@@ -96,6 +96,8 @@ class Synchronizer:
         for p in self.ports:
 
             next_index = self.port_current_frame[p] + 1 # note that this is no longer true if skellycam drops a frame
+            
+
             frame_data_key = f"{p}_{next_index}"
 
             # problem with outpacing the threads reading data in, so wait if need be

--- a/skellycam/opencv/group/synchronizer.py
+++ b/skellycam/opencv/group/synchronizer.py
@@ -1,0 +1,298 @@
+import logging
+
+LOG_FILE = "log\synchronizer.log"
+LOG_LEVEL = logging.DEBUG
+LOG_FORMAT = " %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s"
+
+logging.basicConfig(filename=LOG_FILE, filemode="w", format=LOG_FORMAT, level=LOG_LEVEL)
+
+import sys
+import time
+from pathlib import Path
+from queue import Queue
+from threading import Thread, Event
+
+import cv2
+import numpy as np
+
+class Synchronizer:
+    def __init__(self, streams: dict, fps_target):
+        self.streams = streams
+        self.current_bundle = None
+
+        self.notice_subscribers = []  # queues that will be notified of new bundles
+        self.bundle_subscribers = []    # queues that will receive actual frame data
+        
+        self.frame_data = {}
+        self.stop_event = Event()
+
+        self.ports = []
+        for port, stream in self.streams.items():
+            self.ports.append(port)
+
+        self.fps_target = fps_target
+        if fps_target is not None:
+            self.fps = fps_target
+
+        self.initialize_ledgers()
+        self.spin_up() 
+
+    def stop(self):
+        self.stop_event.set()
+        self.bundler.join()
+        for t in self.threads:
+            t.join()
+            
+        
+    def initialize_ledgers(self):
+
+        self.port_frame_count = {port: 0 for port in self.ports}
+        self.port_current_frame = {port: 0 for port in self.ports}
+        self.mean_frame_times = []
+    
+    def spin_up(self):
+
+        logging.info("About to submit Threadpool of frame Harvesters")
+        self.threads = []
+        for port, stream in self.streams.items():
+            t = Thread(target=self.harvest_frames, args=(stream,), daemon=True)
+            t.start()
+            self.threads.append(t)
+        logging.info("Frame harvesters just submitted")
+
+        logging.info("Starting frame bundler...")
+        self.bundler = Thread(target=self.bundle_frames, args=(), daemon=True)
+        self.bundler.start()
+        
+    def subscribe_to_notice(self, q):
+        # subscribers are notified via the queue that a new frame bundle is available
+        # this is intended to avoid issues with latency due to multiple iterations
+        # of frames being passed from one queue to another
+        logging.info("Adding queue to receive notice of bundle update")
+        self.notice_subscribers.append(q)
+
+    def subscribe_to_bundle(self, q):
+        logging.info("Adding queue to receive frame bundle")
+        self.bundle_subscribers.append(q)
+
+    def release_bundle_q(self,q):
+        logging.info("Releasing record queue")
+        self.bundle_subscribers.remove(q)
+
+    def harvest_frames(self, stream):
+        port = stream.port
+        stream.push_to_reel = True
+
+        logging.info(f"Beginning to collect data generated at port {port}")
+
+        while not self.stop_event.is_set():
+            frame_index = self.port_frame_count[port] 
+
+            (
+                frame_time,
+                frame,
+            ) = stream.reel.get()
+
+            if frame_time == -1: # signal from recorded stream that end of file reached
+                break
+            # once toggled, keep pushing the poison pill
+            
+            self.frame_data[f"{port}_{frame_index}"] = {
+                "port": port,
+                "frame": frame,
+                "frame_index": frame_index,
+                "frame_time": frame_time,
+            }
+
+            logging.debug(f"Frame data harvested from reel {port} with index {frame_index} and frame time of {frame_time}")
+            self.port_frame_count[port] += 1
+
+        logging.info(f"Frame harvester for port {port} completed")
+
+    # get minimum value of frame_time for next layer
+    def earliest_next_frame(self, port):
+        """Looks at next unassigned frame across the ports to determine
+        the earliest time at which each of them was read"""
+        times_of_next_frames = []
+        for p in self.ports:
+            next_index = self.port_current_frame[p] + 1
+            frame_data_key =  f"{p}_{next_index}"
+            
+            # problem with outpacing the threads reading data in, so wait if need be
+            while frame_data_key not in self.frame_data.keys():
+                logging.debug(f"Waiting in a loop for frame data to populate with key: {frame_data_key}")
+                time.sleep(.001)
+
+            next_frame_time = self.frame_data[frame_data_key]["frame_time"]
+            if p != port:
+                times_of_next_frames.append(next_frame_time)
+
+        return min(times_of_next_frames)
+    
+    def latest_current_frame(self, port):
+        """Provides the latest frame_time of the current frames not inclusive of the provided port """
+        times_of_current_frames = []
+        for p in self.ports:
+            current_index = self.port_current_frame[p]
+            current_frame_time = self.frame_data[f"{p}_{current_index}"]["frame_time"]
+            if p != port:
+                times_of_current_frames.append(current_frame_time)
+                
+        return max(times_of_current_frames)
+    
+    def frame_slack(self):
+        """Determine how many unassigned frames are sitting in self.dataframe"""
+
+        slack = [
+            self.port_frame_count[port] - self.port_current_frame[port]
+            for port in self.ports
+        ]
+        logging.debug(f"Slack in frames is {slack}")
+        return min(slack)
+
+    def average_fps(self):
+        """"""
+        # only look at the most recent layers
+        if len(self.mean_frame_times) > 10:
+            self.mean_frame_times = self.mean_frame_times[-10:]
+
+        delta_t = np.diff(self.mean_frame_times)
+        mean_delta_t = np.mean(delta_t)
+
+        return 1 / mean_delta_t
+
+    def bundle_frames(self):
+
+        logging.info(f"Waiting for all ports to begin harvesting corners...")
+
+        # need to have 2 frames to assess bundling
+        for port in self.ports:
+            self.streams[port].shutter_sync.put("fire")
+            self.streams[port].shutter_sync.put("fire")
+
+
+        sync_time = time.perf_counter()
+
+        logging.info("About to start bundling frames...")
+        while not self.stop_event.is_set():
+
+            # Enforce a wait period to hit target FPS, unless you have excess slack
+            if self.frame_slack() < 2:
+                # Trigger device to proceed with reading frame and pushing to reel
+                if self.fps_target is not None:
+                    wait_time = 1 / self.fps_target
+                    while time.perf_counter() < sync_time + wait_time:
+                        time.sleep(0.001)
+
+                sync_time = time.perf_counter()
+                for port in self.ports:
+                    self.streams[port].shutter_sync.put("fire")
+
+            next_layer = {}
+            layer_frame_times = []
+            
+            # build earliest next/latest current dictionaries for each port to determine where to put frames           
+            # must be done before going in and making any updates to the frame index
+            earliest_next = {}
+            latest_current = {}
+            
+
+            for port in self.ports:
+                earliest_next[port] = self.earliest_next_frame(port)
+                latest_current[port] = self.latest_current_frame(port)
+                current_frame_index = self.port_current_frame[port]
+                
+                
+            for port in self.ports:
+                current_frame_index = self.port_current_frame[port]
+
+                port_index_key = f"{port}_{current_frame_index}"
+                current_frame_data = self.frame_data[port_index_key]
+                frame_time = current_frame_data["frame_time"]
+
+                # don't put a frame in a bundle if the next bundle has a frame before it
+                if frame_time > earliest_next[port]:
+                    # definitly should be put in the next layer and not this one
+                    next_layer[port] = None
+                    logging.warning(f"Skipped frame at port {port}: > earliest_next")
+                elif earliest_next[port] - frame_time < frame_time-latest_current[port]: # frame time is closer to earliest next than latest current
+                    # if it's closer to the earliest next frame than the latest current frame, bump it up
+                    # only applying for 2 camera setup where I noticed this was an issue (frames stay out of synch)
+                    next_layer[port] = None
+                    logging.warning(f"Skipped frame at port {port}: delta < time-latest_current")
+                else:
+                    # add the data and increment the index
+                    next_layer[port] = self.frame_data.pop(port_index_key)
+                    self.port_current_frame[port] += 1
+                    layer_frame_times.append(frame_time)
+                    logging.debug(f"Adding to layer from port {port} at index {current_frame_index} and frame time: {frame_time}")
+                    
+            logging.debug(f"Unassigned Frames: {len(self.frame_data)}")
+
+            self.mean_frame_times.append(np.mean(layer_frame_times))
+
+            self.current_bundle = next_layer
+            # notify other processes that the current bundle is ready for processing
+            # only for tasks that can risk missing a frame bundle
+            for q in self.notice_subscribers:
+                logging.debug(f"Giving notice of new bundle via {q}")
+                q.put("new bundle available")
+
+            for q in self.bundle_subscribers:
+                logging.debug(f"Placing new bundle on queue: {q}")
+                logging.debug("Placing bundle on subscribers queue")
+                q.put(self.current_bundle)
+
+            self.fps = self.average_fps()
+
+        logging.info("Frame bundler successfully ended")
+
+if __name__ == "__main__":
+
+    # DON"T DEAL WITH THE SESSION OBJECT IN TESTS...ONLY MORE FOUNDATIONAL ELEMENTS
+    from src.cameras.camera import Camera
+    from src.cameras.live_stream import LiveStream
+    from src.session import Session
+    import pandas as pd
+
+    repo = Path(__file__).parent.parent.parent
+    config_path = Path(repo, "sessions", "high_res_session")
+
+    session = Session(config_path)
+
+    session.load_cameras()
+    session.load_streams()
+    session.adjust_resolutions()
+
+    syncr = Synchronizer(session.streams, fps_target=None)
+
+    notification_q = Queue()
+
+    syncr.subscribe_to_notice(notification_q)
+    
+    bundle_data = {"Bundle":[],
+                   "Port_0_Time":[],
+                   "Port_1_Time":[],
+                   "Port_2_Time":[]}
+    bundle_index = 0
+    while True:
+        frame_bundle_notice = notification_q.get()
+        bundle_data["Bundle"].append(bundle_index)
+        bundle_index += 1
+
+        for port, frame_data in syncr.current_bundle.items():
+            
+            if frame_data:
+                cv2.imshow(f"Port {port}", frame_data["frame"])
+                bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
+            else:
+                bundle_data[f"Port_{port}_Time"].append("dropped")
+                
+        key = cv2.waitKey(1)
+
+        if key == ord("q"):
+            cv2.destroyAllWindows()
+            break
+
+    SynchData = pd.DataFrame(bundle_data)
+    SynchData.to_csv(Path(config_path,"synch_data.csv"))

--- a/skellycam/opencv/group/synchronizer.py
+++ b/skellycam/opencv/group/synchronizer.py
@@ -6,6 +6,7 @@ LOG_FORMAT = " %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s"
 
 logging.basicConfig(filename=LOG_FILE, filemode="w", format=LOG_FORMAT, level=LOG_LEVEL)
 
+from skellycam.detection.models.frame_payload import FramePayload
 import sys
 import time
 from pathlib import Path
@@ -16,8 +17,8 @@ import cv2
 import numpy as np
 
 class Synchronizer:
-    def __init__(self, streams: dict, fps_target):
-        self.streams = streams
+    def __init__(self, ports):
+        # self.streams = streams
         self.current_bundle = None
 
         self.notice_subscribers = []  # queues that will be notified of new bundles
@@ -26,13 +27,13 @@ class Synchronizer:
         self.frame_data = {}
         self.stop_event = Event()
 
-        self.ports = []
-        for port, stream in self.streams.items():
-            self.ports.append(port)
+        self.ports = ports
+        # for port, stream in self.streams.items():
+        #     self.ports.append(port)
 
-        self.fps_target = fps_target
-        if fps_target is not None:
-            self.fps = fps_target
+        # self.fps_target = fps_target
+        # if fps_target is not None:
+            # self.fps = fps_target
 
         self.initialize_ledgers()
         self.spin_up() 
@@ -45,26 +46,27 @@ class Synchronizer:
             
         
     def initialize_ledgers(self):
-
+        # note, these starting values will get overwritten once frames start coming in
+        # the first frame number to actually come in will not be zero based on current testing
         self.port_frame_count = {port: 0 for port in self.ports}
         self.port_current_frame = {port: 0 for port in self.ports}
         self.mean_frame_times = []
     
     def spin_up(self):
 
-        logging.info("About to submit Threadpool of frame Harvesters")
-        self.threads = []
-        for port, stream in self.streams.items():
-            t = Thread(target=self.harvest_frames, args=(stream,), daemon=True)
-            t.start()
-            self.threads.append(t)
-        logging.info("Frame harvesters just submitted")
+        # logging.info("About to submit Threadpool of frame Harvesters")
+        # self.threads = []
+        # for port, stream in self.streams.items():
+        #     t = Thread(target=self.harvest_frames, args=(stream,), daemon=True)
+        #     t.start()
+        #     self.threads.append(t)
+        # logging.info("Frame harvesters just submitted")
 
         logging.info("Starting frame bundler...")
         self.bundler = Thread(target=self.bundle_frames, args=(), daemon=True)
         self.bundler.start()
         
-    def subscribe_to_notice(self, q):
+    def subscribe_to_bundle(self, q):
         # subscribers are notified via the queue that a new frame bundle is available
         # this is intended to avoid issues with latency due to multiple iterations
         # of frames being passed from one queue to another
@@ -79,35 +81,54 @@ class Synchronizer:
         logging.info("Releasing record queue")
         self.bundle_subscribers.remove(q)
 
-    def harvest_frames(self, stream):
-        port = stream.port
-        stream.push_to_reel = True
+    # def harvest_frames(self, stream):
+    #     port = stream.port
+    #     stream.push_to_reel = True
 
-        logging.info(f"Beginning to collect data generated at port {port}")
+    #     logging.info(f"Beginning to collect data generated at port {port}")
 
-        while not self.stop_event.is_set():
-            frame_index = self.port_frame_count[port] 
+    #     while not self.stop_event.is_set():
+    #         frame_index = self.port_frame_count[port] 
 
-            (
-                frame_time,
-                frame,
-            ) = stream.reel.get()
+    #         (
+    #             frame_time,
+    #             frame,
+    #         ) = stream.reel.get()
 
-            if frame_time == -1: # signal from recorded stream that end of file reached
-                break
-            # once toggled, keep pushing the poison pill
+    #         if frame_time == -1: # signal from recorded stream that end of file reached
+    #             break
+    #         # once toggled, keep pushing the poison pill
             
-            self.frame_data[f"{port}_{frame_index}"] = {
-                "port": port,
-                "frame": frame,
-                "frame_index": frame_index,
-                "frame_time": frame_time,
-            }
+    #         self.frame_data[f"{port}_{frame_index}"] = {
+    #             "port": port,
+    #             "frame": frame,
+    #             "frame_index": frame_index,
+    #             "frame_time": frame_time,
+    #         }
 
-            logging.debug(f"Frame data harvested from reel {port} with index {frame_index} and frame time of {frame_time}")
-            self.port_frame_count[port] += 1
+    #         logging.debug(f"Frame data harvested from reel {port} with index {frame_index} and frame time of {frame_time}")
+    #         self.port_frame_count[port] += 1
 
-        logging.info(f"Frame harvester for port {port} completed")
+    #     logging.info(f"Frame harvester for port {port} completed")
+
+    def add_frame_payload(self, payload:FramePayload):
+        
+        # once frames actually start coming in, need to set it to the correct
+        # starting point    
+        if self.port_current_frame[payload.camera_id] == 0:
+            self.port_current_frame[payload.camera_id] = payload.frame_number
+            self.port_frame_count[payload.camera_id] = payload.frame_number
+            
+        print(f"{payload.camera_id}: {payload.frame_number} @ {payload.timestamp_ns/(10^9)}")
+        key = f"{payload.camera_id}_{payload.frame_number}"
+        self.frame_data[key] = {
+            "port": payload.camera_id,
+            "frame": payload.image,
+            "frame_index": self.port_frame_count[payload.camera_id],
+            "frame_time": payload.timestamp_ns,
+        }
+        
+        self.port_frame_count[payload.camera_id] += 1
 
     # get minimum value of frame_time for next layer
     def earliest_next_frame(self, port):
@@ -163,12 +184,12 @@ class Synchronizer:
 
     def bundle_frames(self):
 
-        logging.info(f"Waiting for all ports to begin harvesting corners...")
+        # logging.info(f"Waiting for all ports to begin harvesting corners...")
 
         # need to have 2 frames to assess bundling
-        for port in self.ports:
-            self.streams[port].shutter_sync.put("fire")
-            self.streams[port].shutter_sync.put("fire")
+        # for port in self.ports:
+        #     self.streams[port].shutter_sync.put("fire")
+        #     self.streams[port].shutter_sync.put("fire")
 
 
         sync_time = time.perf_counter()
@@ -177,16 +198,20 @@ class Synchronizer:
         while not self.stop_event.is_set():
 
             # Enforce a wait period to hit target FPS, unless you have excess slack
-            if self.frame_slack() < 2:
-                # Trigger device to proceed with reading frame and pushing to reel
-                if self.fps_target is not None:
-                    wait_time = 1 / self.fps_target
-                    while time.perf_counter() < sync_time + wait_time:
-                        time.sleep(0.001)
+            # if self.frame_slack() < 2:
+            #     # Trigger device to proceed with reading frame and pushing to reel
+            #     if self.fps_target is not None:
+            #         wait_time = 1 / self.fps_target
+            #         while time.perf_counter() < sync_time + wait_time:
+            #             time.sleep(0.001)
 
-                sync_time = time.perf_counter()
-                for port in self.ports:
-                    self.streams[port].shutter_sync.put("fire")
+            #     sync_time = time.perf_counter()
+            #     for port in self.ports:
+            #         self.streams[port].shutter_sync.put("fire")
+
+            # need to wait for data to populate before synchronization can begin
+            while self.frame_slack() < 2:
+                time.sleep(.01)
 
             next_layer = {}
             layer_frame_times = []
@@ -250,49 +275,49 @@ class Synchronizer:
 if __name__ == "__main__":
 
     # DON"T DEAL WITH THE SESSION OBJECT IN TESTS...ONLY MORE FOUNDATIONAL ELEMENTS
-    from src.cameras.camera import Camera
-    from src.cameras.live_stream import LiveStream
-    from src.session import Session
-    import pandas as pd
+    # from src.cameras.camera import Camera
+    # from src.cameras.live_stream import LiveStream
+    # from src.session import Session
+    # import pandas as pd
 
     repo = Path(__file__).parent.parent.parent
     config_path = Path(repo, "sessions", "high_res_session")
 
-    session = Session(config_path)
+    # session = Session(config_path)
 
-    session.load_cameras()
-    session.load_streams()
-    session.adjust_resolutions()
+    # session.load_cameras()
+    # session.load_streams()
+    # session.adjust_resolutions()
 
-    syncr = Synchronizer(session.streams, fps_target=None)
+    # syncr = Synchronizer(session.streams, fps_target=None)
 
-    notification_q = Queue()
+    # notification_q = Queue()
 
-    syncr.subscribe_to_notice(notification_q)
+    # syncr.subscribe_to_notice(notification_q)
     
-    bundle_data = {"Bundle":[],
-                   "Port_0_Time":[],
-                   "Port_1_Time":[],
-                   "Port_2_Time":[]}
-    bundle_index = 0
-    while True:
-        frame_bundle_notice = notification_q.get()
-        bundle_data["Bundle"].append(bundle_index)
-        bundle_index += 1
+    # bundle_data = {"Bundle":[],
+    #                "Port_0_Time":[],
+    #                "Port_1_Time":[],
+    #                "Port_2_Time":[]}
+    # bundle_index = 0
+    # while True:
+    #     frame_bundle_notice = notification_q.get()
+    #     bundle_data["Bundle"].append(bundle_index)
+    #     bundle_index += 1
 
-        for port, frame_data in syncr.current_bundle.items():
+    #     for port, frame_data in syncr.current_bundle.items():
             
-            if frame_data:
-                cv2.imshow(f"Port {port}", frame_data["frame"])
-                bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
-            else:
-                bundle_data[f"Port_{port}_Time"].append("dropped")
+    #         if frame_data:
+    #             cv2.imshow(f"Port {port}", frame_data["frame"])
+    #             bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
+    #         else:
+    #             bundle_data[f"Port_{port}_Time"].append("dropped")
                 
-        key = cv2.waitKey(1)
+    #     key = cv2.waitKey(1)
 
-        if key == ord("q"):
-            cv2.destroyAllWindows()
-            break
+    #     if key == ord("q"):
+    #         cv2.destroyAllWindows()
+    #         break
 
-    SynchData = pd.DataFrame(bundle_data)
-    SynchData.to_csv(Path(config_path,"synch_data.csv"))
+    # SynchData = pd.DataFrame(bundle_data)
+    # SynchData.to_csv(Path(config_path,"synch_data.csv"))

--- a/skellycam/opencv/group/synchronizer.py
+++ b/skellycam/opencv/group/synchronizer.py
@@ -16,42 +16,42 @@ from threading import Thread, Event
 import cv2
 import numpy as np
 
+
 class Synchronizer:
     def __init__(self, ports):
         # self.streams = streams
         self.current_bundle = None
 
         self.notice_subscribers = []  # queues that will be notified of new bundles
-        self.bundle_subscribers = []    # queues that will receive actual frame data
-        
+        self.bundle_subscribers = []  # queues that will receive actual frame data
+
         self.frame_data = {}
         self.stop_event = Event()
 
         self.ports = ports
 
         self.initialize_ledgers()
-        self.spin_up() 
+        self.spin_up()
 
     def stop(self):
         self.stop_event.set()
         self.bundler.join()
         for t in self.threads:
             t.join()
-            
-        
+
     def initialize_ledgers(self):
         # note, these starting values will get overwritten once frames start coming in
         # the first frame number to actually come in will not be zero based on current testing
         self.port_frame_count = {port: 0 for port in self.ports}
         self.port_current_frame = {port: 0 for port in self.ports}
         self.mean_frame_times = []
-    
+
     def spin_up(self):
 
         logging.info("Starting frame bundler...")
         self.bundler = Thread(target=self.bundle_frames, args=(), daemon=True)
         self.bundler.start()
-        
+
     def subscribe_to_bundle(self, q):
         # subscribers are notified via the queue that a new frame bundle is available
         # this is intended to avoid issues with latency due to multiple iterations
@@ -63,20 +63,21 @@ class Synchronizer:
         logging.info("Adding queue to receive frame bundle")
         self.bundle_subscribers.append(q)
 
-    def release_bundle_q(self,q):
+    def release_bundle_q(self, q):
         logging.info("Releasing record queue")
         self.bundle_subscribers.remove(q)
 
+    def add_frame_payload(self, payload: FramePayload):
 
-    def add_frame_payload(self, payload:FramePayload):
-        
         # once frames actually start coming in, need to set it to the correct
-        # starting point    
+        # starting point
         if self.port_current_frame[payload.camera_id] == 0:
             self.port_current_frame[payload.camera_id] = payload.frame_number
             self.port_frame_count[payload.camera_id] = payload.frame_number
-            
-        print(f"{payload.camera_id}: {payload.frame_number} @ {payload.timestamp_ns/(10^9)}")
+
+        print(
+            f"{payload.camera_id}: {payload.frame_number} @ {payload.timestamp_ns/(10^9)}"
+        )
         key = f"{payload.camera_id}_{payload.frame_number}"
         self.frame_data[key] = {
             "port": payload.camera_id,
@@ -84,7 +85,7 @@ class Synchronizer:
             "frame_index": self.port_frame_count[payload.camera_id],
             "frame_time": payload.timestamp_ns,
         }
-        
+
         self.port_frame_count[payload.camera_id] += 1
 
     # get minimum value of frame_time for next layer
@@ -94,30 +95,32 @@ class Synchronizer:
         times_of_next_frames = []
         for p in self.ports:
             next_index = self.port_current_frame[p] + 1
-            frame_data_key =  f"{p}_{next_index}"
-            
+            frame_data_key = f"{p}_{next_index}"
+
             # problem with outpacing the threads reading data in, so wait if need be
             while frame_data_key not in self.frame_data.keys():
-                logging.debug(f"Waiting in a loop for frame data to populate with key: {frame_data_key}")
-                time.sleep(.001)
+                logging.debug(
+                    f"Waiting in a loop for frame data to populate with key: {frame_data_key}"
+                )
+                time.sleep(0.001)
 
             next_frame_time = self.frame_data[frame_data_key]["frame_time"]
             if p != port:
                 times_of_next_frames.append(next_frame_time)
 
         return min(times_of_next_frames)
-    
+
     def latest_current_frame(self, port):
-        """Provides the latest frame_time of the current frames not inclusive of the provided port """
+        """Provides the latest frame_time of the current frames not inclusive of the provided port"""
         times_of_current_frames = []
         for p in self.ports:
             current_index = self.port_current_frame[p]
             current_frame_time = self.frame_data[f"{p}_{current_index}"]["frame_time"]
             if p != port:
                 times_of_current_frames.append(current_frame_time)
-                
+
         return max(times_of_current_frames)
-    
+
     def frame_slack(self):
         """Determine how many unassigned frames are sitting in self.dataframe"""
 
@@ -146,23 +149,21 @@ class Synchronizer:
 
             # need to wait for data to populate before synchronization can begin
             while self.frame_slack() < 2:
-                time.sleep(.01)
+                time.sleep(0.01)
 
             next_layer = {}
             layer_frame_times = []
-            
-            # build earliest next/latest current dictionaries for each port to determine where to put frames           
+
+            # build earliest next/latest current dictionaries for each port to determine where to put frames
             # must be done before going in and making any updates to the frame index
             earliest_next = {}
             latest_current = {}
-            
 
             for port in self.ports:
                 earliest_next[port] = self.earliest_next_frame(port)
                 latest_current[port] = self.latest_current_frame(port)
                 current_frame_index = self.port_current_frame[port]
-                
-                
+
             for port in self.ports:
                 current_frame_index = self.port_current_frame[port]
 
@@ -175,18 +176,24 @@ class Synchronizer:
                     # definitly should be put in the next layer and not this one
                     next_layer[port] = None
                     logging.warning(f"Skipped frame at port {port}: > earliest_next")
-                elif earliest_next[port] - frame_time < frame_time-latest_current[port]: # frame time is closer to earliest next than latest current
+                elif (
+                    earliest_next[port] - frame_time < frame_time - latest_current[port]
+                ):  # frame time is closer to earliest next than latest current
                     # if it's closer to the earliest next frame than the latest current frame, bump it up
                     # only applying for 2 camera setup where I noticed this was an issue (frames stay out of synch)
                     next_layer[port] = None
-                    logging.warning(f"Skipped frame at port {port}: delta < time-latest_current")
+                    logging.warning(
+                        f"Skipped frame at port {port}: delta < time-latest_current"
+                    )
                 else:
                     # add the data and increment the index
                     next_layer[port] = self.frame_data.pop(port_index_key)
                     self.port_current_frame[port] += 1
                     layer_frame_times.append(frame_time)
-                    logging.debug(f"Adding to layer from port {port} at index {current_frame_index} and frame time: {frame_time}")
-                    
+                    logging.debug(
+                        f"Adding to layer from port {port} at index {current_frame_index} and frame time: {frame_time}"
+                    )
+
             logging.debug(f"Unassigned Frames: {len(self.frame_data)}")
 
             self.mean_frame_times.append(np.mean(layer_frame_times))

--- a/skellycam/opencv/group/synchronizer.py
+++ b/skellycam/opencv/group/synchronizer.py
@@ -28,12 +28,6 @@ class Synchronizer:
         self.stop_event = Event()
 
         self.ports = ports
-        # for port, stream in self.streams.items():
-        #     self.ports.append(port)
-
-        # self.fps_target = fps_target
-        # if fps_target is not None:
-            # self.fps = fps_target
 
         self.initialize_ledgers()
         self.spin_up() 
@@ -54,14 +48,6 @@ class Synchronizer:
     
     def spin_up(self):
 
-        # logging.info("About to submit Threadpool of frame Harvesters")
-        # self.threads = []
-        # for port, stream in self.streams.items():
-        #     t = Thread(target=self.harvest_frames, args=(stream,), daemon=True)
-        #     t.start()
-        #     self.threads.append(t)
-        # logging.info("Frame harvesters just submitted")
-
         logging.info("Starting frame bundler...")
         self.bundler = Thread(target=self.bundle_frames, args=(), daemon=True)
         self.bundler.start()
@@ -81,35 +67,6 @@ class Synchronizer:
         logging.info("Releasing record queue")
         self.bundle_subscribers.remove(q)
 
-    # def harvest_frames(self, stream):
-    #     port = stream.port
-    #     stream.push_to_reel = True
-
-    #     logging.info(f"Beginning to collect data generated at port {port}")
-
-    #     while not self.stop_event.is_set():
-    #         frame_index = self.port_frame_count[port] 
-
-    #         (
-    #             frame_time,
-    #             frame,
-    #         ) = stream.reel.get()
-
-    #         if frame_time == -1: # signal from recorded stream that end of file reached
-    #             break
-    #         # once toggled, keep pushing the poison pill
-            
-    #         self.frame_data[f"{port}_{frame_index}"] = {
-    #             "port": port,
-    #             "frame": frame,
-    #             "frame_index": frame_index,
-    #             "frame_time": frame_time,
-    #         }
-
-    #         logging.debug(f"Frame data harvested from reel {port} with index {frame_index} and frame time of {frame_time}")
-    #         self.port_frame_count[port] += 1
-
-    #     logging.info(f"Frame harvester for port {port} completed")
 
     def add_frame_payload(self, payload:FramePayload):
         
@@ -184,30 +141,8 @@ class Synchronizer:
 
     def bundle_frames(self):
 
-        # logging.info(f"Waiting for all ports to begin harvesting corners...")
-
-        # need to have 2 frames to assess bundling
-        # for port in self.ports:
-        #     self.streams[port].shutter_sync.put("fire")
-        #     self.streams[port].shutter_sync.put("fire")
-
-
-        sync_time = time.perf_counter()
-
         logging.info("About to start bundling frames...")
         while not self.stop_event.is_set():
-
-            # Enforce a wait period to hit target FPS, unless you have excess slack
-            # if self.frame_slack() < 2:
-            #     # Trigger device to proceed with reading frame and pushing to reel
-            #     if self.fps_target is not None:
-            #         wait_time = 1 / self.fps_target
-            #         while time.perf_counter() < sync_time + wait_time:
-            #             time.sleep(0.001)
-
-            #     sync_time = time.perf_counter()
-            #     for port in self.ports:
-            #         self.streams[port].shutter_sync.put("fire")
 
             # need to wait for data to populate before synchronization can begin
             while self.frame_slack() < 2:
@@ -271,53 +206,3 @@ class Synchronizer:
             self.fps = self.average_fps()
 
         logging.info("Frame bundler successfully ended")
-
-if __name__ == "__main__":
-
-    # DON"T DEAL WITH THE SESSION OBJECT IN TESTS...ONLY MORE FOUNDATIONAL ELEMENTS
-    # from src.cameras.camera import Camera
-    # from src.cameras.live_stream import LiveStream
-    # from src.session import Session
-    # import pandas as pd
-
-    repo = Path(__file__).parent.parent.parent
-    config_path = Path(repo, "sessions", "high_res_session")
-
-    # session = Session(config_path)
-
-    # session.load_cameras()
-    # session.load_streams()
-    # session.adjust_resolutions()
-
-    # syncr = Synchronizer(session.streams, fps_target=None)
-
-    # notification_q = Queue()
-
-    # syncr.subscribe_to_notice(notification_q)
-    
-    # bundle_data = {"Bundle":[],
-    #                "Port_0_Time":[],
-    #                "Port_1_Time":[],
-    #                "Port_2_Time":[]}
-    # bundle_index = 0
-    # while True:
-    #     frame_bundle_notice = notification_q.get()
-    #     bundle_data["Bundle"].append(bundle_index)
-    #     bundle_index += 1
-
-    #     for port, frame_data in syncr.current_bundle.items():
-            
-    #         if frame_data:
-    #             cv2.imshow(f"Port {port}", frame_data["frame"])
-    #             bundle_data[f"Port_{port}_Time"].append(frame_data["frame_time"])
-    #         else:
-    #             bundle_data[f"Port_{port}_Time"].append("dropped")
-                
-    #     key = cv2.waitKey(1)
-
-    #     if key == ord("q"):
-    #         cv2.destroyAllWindows()
-    #         break
-
-    # SynchData = pd.DataFrame(bundle_data)
-    # SynchData.to_csv(Path(config_path,"synch_data.csv"))


### PR DESCRIPTION
This PR introduces two modules:

- `synchronizer.py` : creates a class that takes in frame payloads via the method `add_frame_payload()` and then puts synchronized frame bundles on a queue as they become available. No frame bundles will be placed until all ports have provided at least two frames. 
-  `synchronize_frame_payloads.py`: an example demonstrating how the Synchronizer can interface with the CameraGroup to create synched frame bundles. For illustration purposes, the synced output is displayed to openCV windows. For later inspection, frame_time and bundle data `.csv` files are saved to the default session directory.

