### PR TITLE
Detect Virtual Cameras using CAP_DSHOW

### DIFF
--- a/skellycam/detection/private/detect_possible_cameras.py
+++ b/skellycam/detection/private/detect_possible_cameras.py
@@ -11,10 +11,6 @@ from skellycam.opencv.config.determine_backend import determine_backend
 logger = logging.getLogger(__name__)
 
 NUMBER_OF_CAMERAS_TO_CHECK = 20  # please give me a reason to increase this number ;D
-# MIN_RESOLUTION_CHECK = 0  # the lowest width value that will be used to determine the minimum resolution of the camera
-# MAX_RESOLUTION_CHECK = 5000  # the highest width value that will be used to determine the maximum resolution of the camera
-# RESOLUTION_CHECK_STEPS = 10  # the number of 'slices" between the minimum and maximum resolutions that will be checked to determine the possible resolutions
-
 
 class DetectPossibleCameras:
     def __init__(self):
@@ -57,13 +53,10 @@ class DetectPossibleCameras:
 
         logger.info(f"Found cameras: {self._cameras_to_use_list}")
 
-        logger.info(
-            f"Verified Resolutions Dictionary: {self._verified_resolutions_dictionary}"
-        )
+
         return FoundCameraCache(
             number_of_cameras_found=len(self._cameras_to_use_list),
             cameras_found_list=self._cameras_to_use_list,
-            verified_resolutions=self._verified_resolutions_dictionary,
         )
 
     def _assess_camera(self, camera_id: Union[str, int]):
@@ -84,6 +77,7 @@ class DetectPossibleCameras:
         is_virtual, new_resolution = self._check_resolution(
             video_capture_object, camera_id, (599, 599)
         )
+        
         if is_virtual:
             logger.info(f"Camera at port {camera_id} is likely virtual")
             return
@@ -104,7 +98,6 @@ class DetectPossibleCameras:
 
         self._cameras_to_use_list.append(str(camera_id))
         self._video_capture_objects_list.append(video_capture_object)
-        # self._verified_resolutions_dictionary[camera_id] = verified_resolutions
 
     def _check_resolution(
         self, video_capture: cv2.VideoCapture, cam_id: int, target_resolution: tuple
@@ -136,52 +129,6 @@ class DetectPossibleCameras:
             )
             return False, None
 
-    def _get_verified_resolutions(
-        self, video_capture: cv2.VideoCapture, cam_id: Union[str, int]
-    ):
-        verified_resolutions = []
-
-        for resolution in RESOLUTIONS_TO_CHECK:
-            # check if resolution is viable
-            width_possible, resolution = self._check_resolution(
-                video_capture, cam_id, target_resolution=resolution
-            )
-            if width_possible:
-                verified_resolutions.append(resolution)
-
-        logger.info(
-            f"At port {cam_id} the following resolutions have been verified {verified_resolutions}"
-        )
-        return verified_resolutions
-
-
-RESOLUTIONS_TO_CHECK = [
-    # (352, 240),
-    # (352, 288),
-    # (352, 480),
-    # (352, 576),
-    # (352, 480),
-    # (480, 480),
-    # (480, 576),
-    # (480, 480),
-    # (480, 576),
-    # (528, 480),
-    # (544, 480),
-    # (544, 576),
-    (640, 480),
-    # (704, 480),
-    # (704, 576),
-    # (720, 480),
-    # (720, 576),
-    # (720, 480),
-    # (720, 576),
-    (1280, 720),
-    (1280, 1080),
-    (1440, 1080),
-    (1920, 1080),
-    # (3840, 2160),
-    # (7680, 4320),
-]
 
 if __name__ == "__main__":
     detector = DetectPossibleCameras()

--- a/skellycam/detection/private/detect_possible_cameras.py
+++ b/skellycam/detection/private/detect_possible_cameras.py
@@ -20,7 +20,7 @@ class DetectPossibleCameras:
     def __init__(self):
         self._cameras_to_use_list = []
         self._video_capture_objects_list = []
-        self._camera_resolutions_dictionary = {}
+        self._verified_resolutions_dictionary = {}
         self._assess_camera_threads = {}
 
         self.backend = determine_backend()
@@ -29,6 +29,7 @@ class DetectPossibleCameras:
 
         # create a dictionary of threads that will check each port for a real camera
         for camera_id in range(NUMBER_OF_CAMERAS_TO_CHECK):
+        # for camera_id in [0]:
             self._assess_camera_threads[camera_id] = Thread(
                 target=self._assess_camera,
                 args=[
@@ -55,10 +56,14 @@ class DetectPossibleCameras:
         del self._video_capture_objects_list
 
         logger.info(f"Found cameras: {self._cameras_to_use_list}")
+
+        logger.info(
+            f"Verified Resolutions Dictionary: {self._verified_resolutions_dictionary}"
+        )
         return FoundCameraCache(
             number_of_cameras_found=len(self._cameras_to_use_list),
             cameras_found_list=self._cameras_to_use_list,
-            possible_resolutions=self._camera_resolutions_dictionary,
+            verified_resolutions=self._verified_resolutions_dictionary,
         )
 
     def _assess_camera(self, camera_id: Union[str, int]):
@@ -72,36 +77,44 @@ class DetectPossibleCameras:
 
         if image1 is None:
             return
-        self.default_resolution = (image1.shape[1],image1.shape[0])
-        possible_resolutions = self._set_possible_resolutions(video_capture_object, camera_id)
 
-        if len(possible_resolutions) == 1:
-            logger.debug(
-                f"Camera {camera_id} has only one possible resolution...likely virtual"
-            )
-        else:
-            logger.debug(
-                f"Camera found at port number {camera_id}: success={success}, "
-                f"image.shape={image1.shape},  cap={video_capture_object}"
-            )
+        # check a non-viable resolution. If accepted by the video capture object, then likely virtual
+        # note that this is the behavior of OpenCV when connecting via CAP_DSHOW on windows
+        # but is not the behavior when connecting via CAP_ANY on windows (instead it returns the nearest viable resolution)
+        is_virtual, new_resolution = self._check_resolution(
+            video_capture_object, camera_id, (599, 599)
+        )
+        if is_virtual:
+            logger.info(f"Camera at port {camera_id} is likely virtual")
+            return
 
-            self._cameras_to_use_list.append(str(camera_id))
-            self._video_capture_objects_list.append(video_capture_object)
-            self._camera_resolutions_dictionary[camera_id] = possible_resolutions
+        self.default_resolution = (image1.shape[1], image1.shape[0])
+        # verified_resolutions = self._get_verified_resolutions(
+        #     video_capture_object, camera_id
+        # )
+
+        logger.debug(
+            f"Camera found at port number {camera_id}: success={success}, "
+            f"image.shape={image1.shape},  cap={video_capture_object}"
+        )
+
+        # reset the VideoCapture object to the original resolution
+        video_capture_object.set(cv2.CAP_PROP_FRAME_WIDTH, self.default_resolution[0])
+        video_capture_object.set(cv2.CAP_PROP_FRAME_HEIGHT, self.default_resolution[1])
+
+        self._cameras_to_use_list.append(str(camera_id))
+        self._video_capture_objects_list.append(video_capture_object)
+        # self._verified_resolutions_dictionary[camera_id] = verified_resolutions
 
     def _check_resolution(
         self, video_capture: cv2.VideoCapture, cam_id: int, target_resolution: tuple
     ):
         """
-        Determine if a given width is viable for a video capture object.
+        Determine if a given resolution is viable for a video capture object.
         Returns a tuple:
             - First return: Bool: indicating whether or not the width is viable
             - Second return: if viable, returns (width,height) combo, otherwise second return value is None
         """
-
-        # 1. store the current resolution of the VideoCapture object to reset it later
-        current_width = int(video_capture.get(cv2.CAP_PROP_FRAME_WIDTH))
-        current_height = int(video_capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
         # 2. attempt to set its width to the provided target_width
         video_capture.set(cv2.CAP_PROP_FRAME_WIDTH, int(target_resolution[0]))
@@ -111,11 +124,7 @@ class DetectPossibleCameras:
         new_width = int(video_capture.get(cv2.CAP_PROP_FRAME_WIDTH))
         new_height = int(video_capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
-        # 4. reset the VideoCapture object to the original resolution
-        video_capture.set(cv2.CAP_PROP_FRAME_WIDTH, current_width)
-        video_capture.set(cv2.CAP_PROP_FRAME_HEIGHT, current_height)
-
-        if new_width == target_resolution:
+        if (new_width, new_height) == target_resolution:
             logger.info(
                 f"At port {cam_id}, camera has a possible resolution of {(new_width, new_height)}"
             )
@@ -127,50 +136,51 @@ class DetectPossibleCameras:
             )
             return False, None
 
-    def _set_possible_resolutions(
+    def _get_verified_resolutions(
         self, video_capture: cv2.VideoCapture, cam_id: Union[str, int]
     ):
-        possible_resolutions = []
+        verified_resolutions = []
 
-        for width in RESOLUTIONS_TO_CHECK:
-            # check if width is viable
+        for resolution in RESOLUTIONS_TO_CHECK:
+            # check if resolution is viable
             width_possible, resolution = self._check_resolution(
-                video_capture, cam_id, target_resolution=width
+                video_capture, cam_id, target_resolution=resolution
             )
             if width_possible:
-                possible_resolutions.append(resolution)
+                verified_resolutions.append(resolution)
 
         logger.info(
-            f"At port {cam_id} the possible resolutions are {possible_resolutions}"
+            f"At port {cam_id} the following resolutions have been verified {verified_resolutions}"
         )
-        return possible_resolutions
+        return verified_resolutions
+
 
 RESOLUTIONS_TO_CHECK = [
-    (352, 240),
-    (352, 288),
-    (352, 480),
-    (352, 576),
-    (352, 480),
-    (480, 480),
-    (480, 576),
-    (480, 480),
-    (480, 576),
-    (528, 480),
-    (544, 480),
-    (544, 576),
+    # (352, 240),
+    # (352, 288),
+    # (352, 480),
+    # (352, 576),
+    # (352, 480),
+    # (480, 480),
+    # (480, 576),
+    # (480, 480),
+    # (480, 576),
+    # (528, 480),
+    # (544, 480),
+    # (544, 576),
     (640, 480),
-    (704, 480),
-    (704, 576),
-    (720, 480),
-    (720, 576),
-    (720, 480),
-    (720, 576),
+    # (704, 480),
+    # (704, 576),
+    # (720, 480),
+    # (720, 576),
+    # (720, 480),
+    # (720, 576),
     (1280, 720),
     (1280, 1080),
     (1440, 1080),
     (1920, 1080),
-    (3840, 2160),
-    (7680, 4320),
+    # (3840, 2160),
+    # (7680, 4320),
 ]
 
 if __name__ == "__main__":

--- a/skellycam/detection/private/found_camera_cache.py
+++ b/skellycam/detection/private/found_camera_cache.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class FoundCameraCache(BaseModel):
     number_of_cameras_found: int
     cameras_found_list: List[str]
-    possible_resolutions: dict
+    verified_resolutions: dict
 
     @property
     def as_camera_list(self):

--- a/skellycam/detection/private/found_camera_cache.py
+++ b/skellycam/detection/private/found_camera_cache.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 class FoundCameraCache(BaseModel):
     number_of_cameras_found: int
     cameras_found_list: List[str]
-    verified_resolutions: dict
 
     @property
     def as_camera_list(self):


### PR DESCRIPTION
This revised code uses the behavior of a virtual camera capture object connected via CAP_DSHOW to identify it and remove it from the list of legitimate cameras. 

In testing on my setup, a CAP_DSHOW virtual camera can be set to *any* resolution, so this Pull Request flags virtual cameras as those that will accept a resolution change to 599x599. 

This is distinct from the behavior of a CAP_ANY virtual camera that can only be set to one resolution.

While the CAP_ANY backend allows quick determination of possible resolutions the CAP_DSHOW backend is more time intensive (~ 1 second per tested resolution). I have removed the resolution verification code from this PR for simplicity's sake. 

The CAP_ANY behavior may be useful for performing camera/resolution validation on MacOS and linux, but I'm not currently set up to test this implementation so leave for a future time.

--------
Tested on: Windows 10

Webcams tested: Logitech Webcam C930e, Logitech C310 HD WebCam, HD Webcam eMeet C960, Razer Kiyo Pro

Virtual Camera: OBS

