### PR TITLE
set object name for detect available camera button

### DIFF
--- a/skellycam/gui/qt/skelly_cam_widget.py
+++ b/skellycam/gui/qt/skelly_cam_widget.py
@@ -207,6 +207,7 @@ class SkellyCamWidget(QWidget):
                                                            border-radius: 10px;
                                                            """)
         detect_available_cameras_push_button.setProperty("recommended_next", True)
+        detect_available_cameras_push_button.setObjectName("detect_available_cameras_button")
 
         return detect_available_cameras_push_button
 


### PR DESCRIPTION
This is a minor PR that will allow the "Detect Available Cameras" button to be differentiated as a "primary button" in the freemocap stylesheet. Without an object name, it can not be singled out in the css from other buttons