### PR TITLE
Annotate charuco points

### DIFF
--- a/skellycam/detection/charuco/charuco_definition.py
+++ b/skellycam/detection/charuco/charuco_definition.py
@@ -1,0 +1,23 @@
+import cv2
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class CharucoBoardDefinition:
+    aruco_marker_dict: Dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)
+    number_of_squares_width: int = 7
+    number_of_squares_height: int = 5
+    black_square_side_length: int = 1
+    aruco_marker_length_proportional: float = 0.8
+
+    def __post_init__(self):
+        self.charuco_board = cv2.aruco.CharucoBoard(
+            size=[self.number_of_squares_width, self.number_of_squares_height],
+            squareLength=self.black_square_side_length,
+            markerLength=self.aruco_marker_length_proportional,
+            dictionary=self.aruco_marker_dict,
+        )
+
+        self.charuco_detector = cv2.aruco.CharucoDetector(self.charuco_board)
+
+        self.charuco_params = cv2.aruco.DetectorParameters()

--- a/skellycam/detection/charuco/charuco_detection.py
+++ b/skellycam/detection/charuco/charuco_detection.py
@@ -1,0 +1,13 @@
+import cv2
+import numpy as np
+
+from skellycam.detection.charuco.charuco_definition import CharucoBoardDefinition
+
+def draw_charuco_on_image(image: np.ndarray, charuco_board: CharucoBoardDefinition) -> None:
+    image_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    
+    charuco_corners, charuco_ids, marker_corners, marker_ids = charuco_board.charuco_detector.detectBoard(image_gray)
+    if not (marker_ids is None) and len(marker_ids) > 0:
+        cv2.aruco.drawDetectedMarkers(image, marker_corners)
+    if not (charuco_ids is None) and len(charuco_ids) >= 4:
+        cv2.aruco.drawDetectedCornersCharuco(image, charuco_corners, charuco_ids)

--- a/skellycam/gui/qt/skelly_cam_widget.py
+++ b/skellycam/gui/qt/skelly_cam_widget.py
@@ -41,6 +41,7 @@ class SkellyCamWidget(QWidget):
             self,
             get_new_synchronized_videos_folder_callable: callable,
             camera_ids: List[Union[str, int]] = None,
+            annotate_images: bool = False,
             parent=None,
     ):
 
@@ -49,6 +50,7 @@ class SkellyCamWidget(QWidget):
         )
 
         self._get_new_synchronized_videos_folder_callable = get_new_synchronized_videos_folder_callable
+        self.annotate_images = annotate_images
 
         self._camera_config_dicationary = None
         self._detect_cameras_worker = None
@@ -182,6 +184,7 @@ class SkellyCamWidget(QWidget):
     def _start_camera_group_frame_worker(self, camera_ids):
 
         logger.info(f"Starting camera group frame worker with camera_ids: {camera_ids}")
+        self._cam_group_frame_worker.annotate_images = self.annotate_images
         self._cam_group_frame_worker.camera_ids = camera_ids
         self._dictionary_of_single_camera_view_widgets = self._create_camera_view_widgets_and_add_them_to_grid_layout(
             camera_config_dictionary=self._cam_group_frame_worker.camera_config_dictionary
@@ -214,6 +217,7 @@ class SkellyCamWidget(QWidget):
         cam_group_frame_worker = CamGroupThreadWorker(
             camera_ids=self._camera_ids,
             get_new_synchronized_videos_folder_callable=self._get_new_synchronized_videos_folder_callable,
+            annotate_images=self.annotate_images
         )
 
         cam_group_frame_worker.cameras_connected_signal.connect(

--- a/skellycam/gui/qt/workers/camera_group_thread_worker.py
+++ b/skellycam/gui/qt/workers/camera_group_thread_worker.py
@@ -120,11 +120,9 @@ class CamGroupThreadWorker(QThread):
                 if frame_payload:
                     if not self._should_pause_bool:
                         if self._should_record_frames_bool:
-                            # TODO: make intermediary after this that groups payloads into synchronized packets
                             self._video_recorder_dictionary[camera_id].append_frame_payload_to_list(frame_payload)
                             logger.info(f"camera:frame_count - {self._get_recorder_frame_count_dict()}")
-                        # TODO: if calibration videos is checked, checked for charuco board, annotate it, then pass annotated image into q image
-                        # add a checkbox to skelly_cam that says "annotate image" - start with making this a bool for the class
+
                         if self.annotate_images:
                             draw_charuco_on_image(image=frame_payload.image, charuco_board=charuco_board)
 

--- a/skellycam/gui/qt/workers/camera_group_thread_worker.py
+++ b/skellycam/gui/qt/workers/camera_group_thread_worker.py
@@ -29,6 +29,7 @@ class CamGroupThreadWorker(QThread):
             self,
             camera_ids: Union[List[str], None],
             get_new_synchronized_videos_folder_callable: callable,
+            annotate_images: bool = False,
             parent=None,
     ):
 
@@ -39,6 +40,7 @@ class CamGroupThreadWorker(QThread):
         super().__init__(parent=parent)
         self._camera_ids = camera_ids
         self._get_new_synchronized_videos_folder_callable = get_new_synchronized_videos_folder_callable
+        self.annotate_images = annotate_images
 
         self._should_pause_bool = False
         self._should_record_frames_bool = False
@@ -98,7 +100,7 @@ class CamGroupThreadWorker(QThread):
     def is_recording(self):
         return self._should_record_frames_bool
 
-    def run(self, annotate_images: bool = True):
+    def run(self):
         logger.info("Starting camera group thread worker")
         self._camera_group.start()
         should_continue = True
@@ -106,7 +108,7 @@ class CamGroupThreadWorker(QThread):
         logger.info("Emitting `cameras_connected_signal`")
         self.cameras_connected_signal.emit()
 
-        if annotate_images:
+        if self.annotate_images:
             charuco_board = CharucoBoardDefinition()
 
         while self._camera_group.is_capturing and should_continue:
@@ -123,9 +125,9 @@ class CamGroupThreadWorker(QThread):
                             logger.info(f"camera:frame_count - {self._get_recorder_frame_count_dict()}")
                         # TODO: if calibration videos is checked, checked for charuco board, annotate it, then pass annotated image into q image
                         # add a checkbox to skelly_cam that says "annotate image" - start with making this a bool for the class
-                        if annotate_images:
+                        if self.annotate_images:
                             draw_charuco_on_image(image=frame_payload.image, charuco_board=charuco_board)
-                            
+
                         q_image = self._convert_frame(frame_payload)
 
                         frame_diagnostic_dictionary = {}


### PR DESCRIPTION
Add option to draw charuco points when detected on images. Also passes down a boolean accessible from SkellyCamWidget that tells whether to annotate images or not.

<img width="1136" alt="Screen Shot 2023-09-13 at 7 14 21 PM" src="https://github.com/freemocap/skellycam/assets/24758117/4d3e00f6-5963-4565-9267-70fc7a5a5133">
Charuco is not fully showing on image above due to glare on the phone screen.