### PR TITLE
Pydantic 2 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ ENV/
 site/
 
 pip*
+
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ site/
 pip*
 
 node_modules/
+.nuxt/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ keywords = [
 dependencies = [
 "numpy==1.26.2",
 "opencv-contrib-python==4.8.*",
-"pydantic==1.*",
+"pydantic==2.*",
 "Pillow==10.0.1",
 "psutil==5.9.6",
 "setproctitle==1.3.3",


### PR DESCRIPTION
This Pr just ups the version identifier for pydantic in pyproject.toml from `1.*` to `2.*`. the `bump-pydantic` tool didn't find anything to change, and running skellycam with pydantic 2.7 seemed to work properly.

## Extra Testing:
There are pydantic references in the timestamp plotting code, which doesn't run on mac. Someone with a windows or linux machine should run through a recording to make sure the plots still generate correctly.