### PR TITLE
Fix camera config validation

### DIFF
--- a/skellycam/gui/qt/utilities/qt_label_strings.py
+++ b/skellycam/gui/qt/utilities/qt_label_strings.py
@@ -12,7 +12,7 @@ EXPAND_ALL_STRING = "Expand All"
 COLLAPSE_ALL_STRING = "Collapse All"
 
 
-def rotate_image_str_to_cv2_code(rotate_str: str):
+def rotate_image_str_to_cv2_code(rotate_str: str) -> int:
     if rotate_str == ROTATE_90_CLOCKWISE_STRING:
         return cv2.ROTATE_90_CLOCKWISE
     elif rotate_str == ROTATE_90_COUNTERCLOCKWISE_STRING:
@@ -20,11 +20,11 @@ def rotate_image_str_to_cv2_code(rotate_str: str):
     elif rotate_str == ROTATE_180_STRING:
         return cv2.ROTATE_180
 
-    return None
+    return 0
 
 
 def rotate_cv2_code_to_str(rotate_video_value):
-    if rotate_video_value is None:
+    if rotate_video_value is None or rotate_video_value == 0:
         return None
     elif rotate_video_value == cv2.ROTATE_90_CLOCKWISE:
         return ROTATE_90_CLOCKWISE_STRING

--- a/skellycam/opencv/camera/internal_camera_thread.py
+++ b/skellycam/opencv/camera/internal_camera_thread.py
@@ -116,7 +116,7 @@ class VideoCaptureThread(threading.Thread):
             self._cv2_video_capture.grab()
             success, image = self._cv2_video_capture.retrieve()
             retrieval_timestamp = time.perf_counter_ns()
-            if self._config.rotate_video_cv2_code is not None:
+            if self._config.rotate_video_cv2_code != 0:
                 image = cv2.rotate(image, self._config.rotate_video_cv2_code)
 
         except:

--- a/skellycam/opencv/camera/models/camera_config.py
+++ b/skellycam/opencv/camera/models/camera_config.py
@@ -4,12 +4,12 @@ from skellycam.opencv.camera.types.camera_id import CameraId
 
 
 class CameraConfig(BaseModel):
-    camera_id: CameraId = 0
+    camera_id: CameraId = "0"
     exposure: int = -7
     resolution_width: int = 960
     resolution_height: int = 540
     framerate: int = 30
     # fourcc: str = "MP4V"
     fourcc: str = "MJPG"
-    rotate_video_cv2_code: int = None
+    rotate_video_cv2_code: int = 0
     use_this_camera: bool = True


### PR DESCRIPTION
Fixes a Pydantic validation error where we were setting an `int` field to `None`, breaking the camera config setting.

Representative error from Discord:
```
[2024-08-10T16:40:27.619482] [Δt:0.942122s] [    INFO] [skellycam.gui.qt.widgets.skelly_cam_config_parameter_tree_widget] [skelly_cam_config_parameter_tree_widget:_extract_dictionary_of_camera_configs():208] [PID:20124:MainProcess TID:17372:MainThread ] Extracting camera configs from parameter tree
2024-08-10 16:40:27,619 - skellycam.gui.qt.widgets.skelly_cam_config_parameter_tree_widget - INFO - Extracting camera configs from parameter tree
Traceback (most recent call last):
  File "C:\Users\AppData\Local\Programs\Python\Python312\Lib\site-packages\skellycam\gui\qt\widgets\skelly_cam_config_parameter_tree_widget.py", line 139, in _emit_camera_configs_dict
    camera_configs_dictionary = self._extract_dictionary_of_camera_configs()
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\AppData\Local\Programs\Python\Python312\Lib\site-packages\skellycam\gui\qt\widgets\skelly_cam_config_parameter_tree_widget.py", line 214, in extractdictionaryofcamera_configs
    camera_config_dictionary[camera_id] = CameraConfig(
                                          ^^^^^^^^^^^^^
  File "C:\Users\AppData\Local\Programs\Python\Python312\Lib\site-packages\pydantic\main.py", line 193, in __init
    self.__pydantic_validator.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for CameraConfig
rotate_video_cv2_code
  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.8/v/int_type
    ```