### PR TITLE
Patch: Camera Config ignores 90 Clockwise Rotations

### DIFF
--- a/skellycam/gui/qt/utilities/qt_label_strings.py
+++ b/skellycam/gui/qt/utilities/qt_label_strings.py
@@ -20,11 +20,11 @@ def rotate_image_str_to_cv2_code(rotate_str: str) -> int:
     elif rotate_str == ROTATE_180_STRING:
         return cv2.ROTATE_180
 
-    return 0
+    return -1
 
 
 def rotate_cv2_code_to_str(rotate_video_value):
-    if rotate_video_value is None or rotate_video_value == 0:
+    if rotate_video_value is None or rotate_video_value == -1:
         return None
     elif rotate_video_value == cv2.ROTATE_90_CLOCKWISE:
         return ROTATE_90_CLOCKWISE_STRING

--- a/skellycam/opencv/camera/internal_camera_thread.py
+++ b/skellycam/opencv/camera/internal_camera_thread.py
@@ -116,7 +116,7 @@ class VideoCaptureThread(threading.Thread):
             self._cv2_video_capture.grab()
             success, image = self._cv2_video_capture.retrieve()
             retrieval_timestamp = time.perf_counter_ns()
-            if self._config.rotate_video_cv2_code != 0:
+            if self._config.rotate_video_cv2_code != -1:
                 image = cv2.rotate(image, self._config.rotate_video_cv2_code)
 
         except:

--- a/skellycam/opencv/camera/models/camera_config.py
+++ b/skellycam/opencv/camera/models/camera_config.py
@@ -11,5 +11,5 @@ class CameraConfig(BaseModel):
     framerate: int = 30
     # fourcc: str = "MP4V"
     fourcc: str = "MJPG"
-    rotate_video_cv2_code: int = 0
+    rotate_video_cv2_code: int = -1
     use_this_camera: bool = True


### PR DESCRIPTION
In the last patch (#60) we used `0` as a value for "no rotation", but this conflicts with openCV's rotation enum (`cv.ROTATE_90_CLOCKWISE == 0 # returns True`).

This patch uses `-1` for the "no rotation" value instead (openCV does not provide its own "no rotation" value).

I have tested that this runs and correctly rotates the image in each of the 4 settings (no rotation, 90 CW, 90 CCW, 180) and does not throw any errors.