### PR TITLE
Added auto exposure support

### DIFF
--- a/skellycam/gui/qt/widgets/skelly_cam_config_parameter_tree_widget.py
+++ b/skellycam/gui/qt/widgets/skelly_cam_config_parameter_tree_widget.py
@@ -160,7 +160,11 @@ class SkellyCamParameterTreeWidget(QWidget):
                     ],
                     value=rotate_cv2_code_to_str(camera_config.rotate_video_cv2_code),
                 ),
-                dict(name="Exposure", type="int", value=camera_config.exposure),
+                dict(
+                    name="Exposure", 
+                    type="str", 
+                    value=camera_config.exposure
+                ),
                 dict(
                     name="Resolution Width",
                     type="int",

--- a/skellycam/opencv/camera/models/camera_config.py
+++ b/skellycam/opencv/camera/models/camera_config.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel
+from typing import Union
 
 from skellycam.opencv.camera.types.camera_id import CameraId
 
 
 class CameraConfig(BaseModel):
     camera_id: CameraId = "0"
-    exposure: int = -7
+    exposure: Union[int, str] = -7  # Supports either an int or "auto" for exposure level
     resolution_width: int = 960
     resolution_height: int = 540
     framerate: int = 30

--- a/skellycam/opencv/config/apply_config.py
+++ b/skellycam/opencv/config/apply_config.py
@@ -1,12 +1,9 @@
 import logging
 import traceback
-
 import cv2
-
 from skellycam.opencv.camera.models.camera_config import CameraConfig
 
 logger = logging.getLogger(__name__)
-
 
 def apply_configuration(cv2_vid_cap: cv2.VideoCapture, config: CameraConfig):
     # set camera stream parameters
@@ -32,7 +29,19 @@ def apply_configuration(cv2_vid_cap: cv2.VideoCapture, config: CameraConfig):
         return
 
     try:
-        cv2_vid_cap.set(cv2.CAP_PROP_EXPOSURE, config.exposure)
+        # Handle exposure setting
+        if isinstance(config.exposure, str) and config.exposure.lower() == "auto":
+            cv2_vid_cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.75)  # 0.75 enables auto exposure
+        else:
+            try:
+                # Attempt to set the exposure as an integer
+                exposure_value = int(config.exposure)
+                cv2_vid_cap.set(cv2.CAP_PROP_EXPOSURE, exposure_value)
+            except ValueError:
+                logger.error(
+                    f"Invalid exposure value: {config.exposure}. It must be an integer or 'auto'."
+                )
+                return
         cv2_vid_cap.set(cv2.CAP_PROP_FRAME_WIDTH, config.resolution_width)
         cv2_vid_cap.set(cv2.CAP_PROP_FRAME_HEIGHT, config.resolution_height)
         cv2_vid_cap.set(cv2.CAP_PROP_FPS, config.framerate)


### PR DESCRIPTION
When using some webcams the exposure setting does not correctly adjust the camera's exposure, leaving the surroundings much darker than they should be. This can be seen here as the exposure is set to -7 by default the camera shows a completely black screen.

![image](https://github.com/user-attachments/assets/688312a9-6814-4f46-bf01-88d043d180b1)

Even after adjusting this value the room is still barely visible and not acceptable for mocap.

![image](https://github.com/user-attachments/assets/e3d0aa42-25cc-4a0a-a1f4-c27a7d37188c)

By allowing string inputs on the exposure field we can set the camera's exposure to automatic when "auto" is entered, switching to automatic exposure and instantly brightening the room up to an acceptable level. This field still accepts integer entries for those who want to use it.

![image](https://github.com/user-attachments/assets/9b5aa010-0cd4-4f65-a4f2-b099897db8c6)

Video of change:

![ezgif-7-ca53b40e67](https://github.com/user-attachments/assets/62558e53-c297-4859-8cfe-a3330c437187)

