### PR TITLE
Handle virtual cameras and device ordering properly on Mac

### DIFF
--- a/skellycam/core/detection/camera_device_info.py
+++ b/skellycam/core/detection/camera_device_info.py
@@ -62,12 +62,11 @@ class CameraDeviceInfo(BaseModel):
     def from_q_camera_device(cls, camera_number: int, camera: QCameraDevice):
         device_address = camera.id().data().decode("utf-8")
         try:
-            if platform.system() == 'Windows':
+            if platform.system() == 'Windows' or platform.system() == 'Darwin':
                 logger.trace(f"Windows detected, using camera number as cv2 port")
                 cv2_port = camera_number
             else:
                 logger.trace(f"Non-Windows detected, using camera address as cv2 port")
-                # TODO: this doesn't work on mac, device address looks like "obs-virtual-cam-device" or "47B4B64B70674B9CAD2BAE273A71F4B5"
                 cv2_port = device_address.split("video")[1]
         except Exception as e:
             cv2_port = camera_number

--- a/skellycam/core/detection/detect_available_devices.py
+++ b/skellycam/core/detection/detect_available_devices.py
@@ -1,8 +1,11 @@
 import logging
+import platform
 from pprint import pprint
+from typing import List, Tuple
 
 import cv2
 from PySide6.QtCore import QCoreApplication
+from PySide6.QtMultimedia import QCameraDevice
 
 from skellycam.api.app.app_state import get_app_state
 from skellycam.core.detection.camera_device_info import CameraDeviceInfo
@@ -21,8 +24,13 @@ async def detect_available_devices(check_if_available: bool = False):
     devices = QMediaDevices()
     detected_cameras = devices.videoInputs()
 
+    if platform.system() == "Darwin":
+        detected_cameras, camera_ports = await order_darwin_cameras(detected_cameras=detected_cameras)
+    else:
+        camera_ports = range(len(detected_cameras))
+
     camera_devices = {}
-    for camera_number, camera in enumerate(detected_cameras):
+    for camera_number, camera in zip(camera_ports, detected_cameras):
 
         if check_if_available:
             await _check_camera_available(camera_number)
@@ -45,6 +53,38 @@ async def _check_camera_available(port: int) -> bool:
     logger.debug(f"Camera on port: {port} is available!")
     cap.release()
     return True
+
+async def order_darwin_cameras(detected_cameras: List[QCameraDevice]) -> Tuple[List[QCameraDevice], List[int]]:
+    """
+    Reorder QMultiMediaDevices to match order of OpenCV ports on macOS. 
+
+    Removes virtual cameras, and assumes virtual cameras are always last. 
+    Also assumes that once virtual cameras are removed, the order of the cameras from Qt will match the order of OpenCV.
+    """
+    camera_ports = await detect_opencv_ports()
+    for camera in detected_cameras:
+        if "Virtual" in camera.description():
+            detected_cameras.remove(camera)
+            camera_ports.pop()  # assumes virtual camera is always last
+    if len(camera_ports) != len(detected_cameras):
+        raise ValueError(f"OpenCV and Qt did not detect same number of cameras: OpenCV: {len(camera_ports)} !=  Qt: {len(detected_cameras)}")
+
+    return detected_cameras, camera_ports
+
+
+async def detect_opencv_ports(max_ports: int = 20, max_unused_ports: int = 5) -> List[int]:
+    unused = 0
+    port = 0
+    ports = []
+    while port < max_ports and unused < max_unused_ports:
+        camera_available = await _check_camera_available(port)
+        if camera_available:
+            ports.append(port)
+        else:
+            unused += 1
+        port += 1
+
+    return ports
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds proper camera handling for Mac systems. It operates on the assumption that virtual cameras are always on the highest available port for OpenCV, and that once the virtual camera is removed the detection order for OpenCV/Qt match.

At some later point we may want a more robust method or matching these two, but this *works on my machine*.