### PR TITLE
add help behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ push            = true
 #dependencies = {file = "requirements.txt"}
 
 [project.scripts]
-skellycam = "skellycam.__main__:main"
+skellycam = "skellycam.__main__:run"
 
 [tool.setuptools]
 py-modules = ["skellycam"]

--- a/skellycam/__main__.py
+++ b/skellycam/__main__.py
@@ -2,17 +2,26 @@
 import platform
 import sys
 from pathlib import Path
-
-try:
-    from skellycam.gui.qt.main import qt_gui_main
-except Exception as e:
-    base_package_path = Path(__file__).parent.parent
-    print(f"adding base_package_path: {base_package_path} : to sys.path")
-    sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
-    from skellycam.gui.qt.main import qt_gui_main
+import argparse
 
 
-def main():
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="SkellyCam")
+    return parser.parse_args()
+
+def run():
+    parse_args()
+    
+    try:
+        from skellycam.gui.qt.main import qt_gui_main
+    except Exception as e:
+        base_package_path = Path(__file__).parent.parent
+        print(f"adding base_package_path: {base_package_path} : to sys.path")
+        sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
+        from skellycam.gui.qt.main import qt_gui_main
+    
+    
     qt_gui_main()
 
 
@@ -26,4 +35,5 @@ if __name__ == "__main__":
         myappid = f"{skellycam.__package_name__}_{skellycam.__version__}"  # arbitrary string
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
-    main()
+    run()
+


### PR DESCRIPTION
Adding help behavior to `skellycam`

To test:

1) Create a fresh install of `skellycam` for this PR
2) Try `skellycam --help` 
3) Try `python -m skellycam --help`

for 2 and 3 you should get a print statement that reads:
```
(skellycam) C:\Users\aaron\Documents\GitHub\skellycam>python -m skellycam --help
adding base_package_path: C:\Users\aaron\Documents\GitHub\skellycam\skellycam : to sys.path
Setting up skellycam logging C:\Users\aaron\Documents\GitHub\skellycam\skellycam\system\log_config\logsetup.py
[2025-01-09 13:00:57.0603] [    INFO] [skellycam.system.log_config.logsetup] [configure_logging():39] [PID:25280 TID:47420] Added logging handlers: [<StreamHandler <stdout> (DEBUG)>, <FileHandler C:\Users\aaron\skelly-cam-recordings\logs_info_and_settings\logs\log_2025-01-09T13_00_57ms601_gmt-5.log (DEBUG)>]
[2025-01-09 13:00:57.0603] [    INFO] [skellycam] [<module>():27] [PID:25280 TID:47420] Initializing skellycam package, version: v2024.09.1094, from file: C:\Users\aaron\Documents\GitHub\skellycam\skellycam\__init__.py
Running `skellycam.__main__` from - C:\Users\aaron\Documents\GitHub\skellycam\skellycam\__main__.py
usage: __main__.py [-h]

SkellyCam

options:
  -h, --help  show this help message and exit
  ```
  
  NOTE: I changed the entry point in the `pyproject.toml` in order to get `skellycam --help` to work in addition to `python -m skellycam --help` 