### PR TITLE
Replace queue.qsize with queue.empty in jon/development

### DIFF
--- a/skellycam/api/websocket/websocket_server.py
+++ b/skellycam/api/websocket/websocket_server.py
@@ -50,7 +50,7 @@ class WebsocketServer:
 
         try:
             while True:
-                if self._app_state.ipc_queue.qsize() > 0:
+                if not self._app_state.ipc_queue.empty():
                     try:
                         await self._handle_ipc_queue_message(message=self._app_state.ipc_queue.get())
                     except multiprocessing.queues.Empty:

--- a/skellycam/core/camera_group/camera/camera_manager.py
+++ b/skellycam/core/camera_group/camera/camera_manager.py
@@ -86,13 +86,13 @@ class CameraManager(BaseModel):
 
     def _check_handle_config_update(self):
         # Check for new camera configs
-        if self.camera_group_dto.config_update_queue.qsize() > 0:
+        if not self.camera_group_dto.config_update_queue.empty():
             logger.trace(f"Handling camera config updates for cameras: {self.camera_ids}")
             update_instructions = self.camera_group_dto.config_update_queue.get()
 
             self.update_camera_configs(update_instructions)
             while any(
-                    [camera_process.new_config_queue.qsize() > 0 for camera_process in self.camera_processes.values()]):
+                    [not camera_process.new_config_queue.empty() for camera_process in self.camera_processes.values()]):
                 wait_100ms()
             self.orchestrator.await_cameras_ready()
             logger.trace(f"Camera configs updated for cameras: {self.camera_ids}")

--- a/skellycam/core/camera_group/camera/camera_process.py
+++ b/skellycam/core/camera_group/camera/camera_process.py
@@ -141,7 +141,7 @@ def check_for_config_update(config: CameraConfig,
                             cv2_video_capture: cv2.VideoCapture,
                             new_config_queue: multiprocessing.Queue,
                             frame_loop_flags: CameraFrameLoopFlags) -> CameraConfig:
-    if new_config_queue.qsize() > 0:
+    if not new_config_queue.empty():
         logger.debug(f"Camera {config.camera_id} received new config update - setting `not ready`")
         frame_loop_flags.set_camera_not_ready()
         config = new_config_queue.get()

--- a/skellycam/core/camera_group/camera_manager.py
+++ b/skellycam/core/camera_group/camera_manager.py
@@ -89,13 +89,13 @@ class CameraManager(BaseModel):
 
     def _check_handle_config_update(self):
         # Check for new camera configs
-        if self.camera_group_dto.config_update_queue.qsize() > 0:
+        if not self.camera_group_dto.config_update_queue.empty():
             logger.trace(f"Handling camera config updates for cameras: {self.camera_ids}")
             update_instructions = self.camera_group_dto.config_update_queue.get()
 
             self.update_camera_configs(update_instructions)
             while any(
-                    [camera_process.new_config_queue.qsize() > 0 for camera_process in self.camera_processes.values()]):
+                    [not camera_process.new_config_queue.empty() for camera_process in self.camera_processes.values()]):
                 wait_100ms()
             self.orchestrator.await_cameras_ready()
             logger.trace(f"Camera configs updated for cameras: {self.camera_ids}")

--- a/skellycam/core/frames/wrangling/frame_listener_process.py
+++ b/skellycam/core/frames/wrangling/frame_listener_process.py
@@ -50,7 +50,7 @@ class FrameListenerProcess:
         try:
 
             while not camera_group_dto.ipc_flags.kill_camera_group_flag.value and not camera_group_dto.ipc_flags.global_kill_flag.value:
-                if new_configs_queue.qsize() > 0:
+                if not new_configs_queue.empty():
                     camera_configs = new_configs_queue.get()
 
                 if orchestrator.should_pull_multi_frame_from_shm.value and orchestrator.new_multi_frame_available:

--- a/skellycam/core/frames/wrangling/frame_router_process.py
+++ b/skellycam/core/frames/wrangling/frame_router_process.py
@@ -69,7 +69,7 @@ class FrameRouterProcess:
                 wait_1ms()
 
                 # Check for new camera configs
-                if new_configs_queue.qsize() > 0:
+                if not new_configs_queue.empty():
                     camera_configs = new_configs_queue.get()
 
                 # Fully drain the ring shm buffer every time and put the frames into a deque in this Process' memory


### PR DESCRIPTION
The `queue.qsize` method does not work on MacOS - see the note here: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue.qsize

This PR just changes instances of `queue.qsize() > 0` with `not ...queue.empty()`.