### PR TITLE
Accept different charuco boards

### DIFF
--- a/skellycam/detection/charuco/charuco_definition.py
+++ b/skellycam/detection/charuco/charuco_definition.py
@@ -4,11 +4,12 @@ from typing import Dict
 
 @dataclass
 class CharucoBoardDefinition:
+    name: str
+    number_of_squares_width: int
+    number_of_squares_height: int
+    black_square_side_length: int
+    aruco_marker_length_proportional: float
     aruco_marker_dict: Dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)
-    number_of_squares_width: int = 7
-    number_of_squares_height: int = 5
-    black_square_side_length: int = 1
-    aruco_marker_length_proportional: float = 0.8
 
     def __post_init__(self):
         self.charuco_board = cv2.aruco.CharucoBoard(
@@ -18,6 +19,30 @@ class CharucoBoardDefinition:
             dictionary=self.aruco_marker_dict,
         )
 
-        self.charuco_detector = cv2.aruco.CharucoDetector(self.charuco_board)
+        self.number_of_charuco_corners = (self.number_of_squares_width - 1) * (self.number_of_squares_height - 1)
 
-        self.charuco_params = cv2.aruco.DetectorParameters()
+
+def charuco_7x5() -> CharucoBoardDefinition:
+    return CharucoBoardDefinition(
+        name="full_board_7x5",
+        number_of_squares_width=7,
+        number_of_squares_height=5,
+        black_square_side_length=1,
+        aruco_marker_length_proportional=0.8,
+    )
+
+
+def charuco_5x3() -> CharucoBoardDefinition:
+    return CharucoBoardDefinition(
+        name="mini_board_5x3",
+        number_of_squares_width=5,
+        number_of_squares_height=3,
+        black_square_side_length=1,
+        aruco_marker_length_proportional=0.8,
+    )
+
+
+CHARUCO_BOARDS = {
+    "Full Charuco (7x5)": charuco_7x5,
+    "Mini Charuco (5x3)": charuco_5x3,
+}

--- a/skellycam/detection/charuco/charuco_definition.py
+++ b/skellycam/detection/charuco/charuco_definition.py
@@ -20,6 +20,7 @@ class CharucoBoardDefinition:
         )
 
         self.number_of_charuco_corners = (self.number_of_squares_width - 1) * (self.number_of_squares_height - 1)
+        self.charuco_detector = cv2.aruco.CharucoDetector(self.charuco_board)
 
 
 def charuco_7x5() -> CharucoBoardDefinition:

--- a/skellycam/gui/qt/skelly_cam_widget.py
+++ b/skellycam/gui/qt/skelly_cam_widget.py
@@ -287,6 +287,9 @@ class SkellyCamWidget(QWidget):
             camera_config_dictionary=camera_config_dictionary
         )
 
+    def set_charuco_board(self, charuco_name: str):
+        self._cam_group_frame_worker.charuco_board = charuco_name
+
     def _get_landscape_or_portrait(self, camera_config: CameraConfig) -> str:
         if (
                 camera_config.rotate_video_cv2_code == cv2.ROTATE_90_CLOCKWISE


### PR DESCRIPTION
This PR allows the new charuco board selection option to be used with the charuco overlay option. This means the 5x3 board will be able to be detected for the overlay option, not just the original 7x5 board.

It works by creating a function for `SkellyCamWidget` to accept different charuco board names, that it then passes to the `CamGroupThreadWorker`, which creates a charuco board object that is used for the Charuco Overlay option.

Right now, I'm passing the name of the board into skellycam. We can pass the entire board definition in, which will require changing freemocap's board definition to include a detector object (adding this to the __post_init__: `self.charuco_detector = cv2.aruco.CharucoDetector(self.charuco_board)`)