### PR TITLE
Move camera detection to backend

### DIFF
--- a/skellycam-ui/package.json
+++ b/skellycam-ui/package.json
@@ -29,6 +29,7 @@
     "@mui/icons-material": "^6.4.5",
     "@mui/material": "^6.1.1",
     "@mui/x-tree-view": "^7.28.1",
+    "@react-buddy/ide-toolbox": "^2.4.0",
     "@react-three/drei": "^10.4.2",
     "@react-three/fiber": "^9.1.4",
     "@reduxjs/toolkit": "^2.5.1",
@@ -43,7 +44,7 @@
     "react-use": "^17.5.1",
     "three": "^0.178.0",
     "tree-kill": "^1.2.2",
-    "@react-buddy/ide-toolbox": "^2.4.0"
+    "zod": "^4.0.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",

--- a/skellycam-ui/src/components/available-cameras-panel/AvailableCamerasPanel.tsx
+++ b/skellycam-ui/src/components/available-cameras-panel/AvailableCamerasPanel.tsx
@@ -11,12 +11,12 @@ import {RefreshDetectedCamerasButton} from "@/components/available-cameras-panel
 import {useAppDispatch, useAppSelector} from "@/store/AppStateStore";
 import {ConnectToCamerasButton} from "@/components/available-cameras-panel/ConnectToCamerasButton";
 import {selectAllCameras, toggleCameraSelection, updateCameraConfig,} from "@/store/slices/cameras-slices/camerasSlice";
-import {detectCameraDevices} from "@/store/thunks/detect-cameras-client-thunks";
 import {connectToCameras} from "@/store/thunks/connect-to-cameras-thunk";
 import {CloseCamerasButton} from "@/components/available-cameras-panel/CloseCamerasButton";
 import {CameraConfig} from "@/store/slices/cameras-slices/camera-types";
 import {ApplyCameraConfigsButton} from "@/components/available-cameras-panel/ApplyCameraConfigsButton";
 import {PauseUnpauseButton} from "../PauseUnpauseButton";
+import { detectCameraDevices } from "@/store/thunks/detect-cameras-server-thunk";
 
 export const AvailableCamerasPanel = () => {
     const theme = useTheme();
@@ -50,7 +50,7 @@ export const AvailableCamerasPanel = () => {
 
     // Initial camera detection
     useEffect(() => {
-        dispatch(detectCameraDevices(true));
+        dispatch(detectCameraDevices());
     }, [dispatch]);
 
     // Handle connection to selected cameras

--- a/skellycam-ui/src/components/available-cameras-panel/RefreshDetectedCameras.tsx
+++ b/skellycam-ui/src/components/available-cameras-panel/RefreshDetectedCameras.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { CircularProgress, IconButton, Tooltip } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { useAppDispatch } from '@/store/AppStateStore';
-import { detectCameraDevices } from "@/store/thunks/detect-cameras-client-thunks";
+import { detectCameraDevices } from '@/store/thunks/detect-cameras-server-thunk';
 
 interface RefreshDetectedCamerasButtonProps {
     isLoading: boolean;
@@ -14,7 +14,7 @@ export const RefreshDetectedCamerasButton: React.FC<RefreshDetectedCamerasButton
 
     const handleRefresh = () => {
         if (!isLoading) {
-            dispatch(detectCameraDevices(true));
+            dispatch(detectCameraDevices());
         }
     };
 

--- a/skellycam-ui/src/services/urlService.ts
+++ b/skellycam-ui/src/services/urlService.ts
@@ -41,6 +41,7 @@ class UrlService {
   // Camera API endpoints
   getCameraUrls() {
     return {
+      detectCameras: this.getApiUrl('/camera/detect'),
       createGroup: this.getApiUrl('/camera/group/create'),
       closeAll: this.getApiUrl('/camera/group/close/all'),
       updateConfig: this.getApiUrl('/camera/update'),

--- a/skellycam-ui/src/store/slices/cameras-slices/camera-types.ts
+++ b/skellycam-ui/src/store/slices/cameras-slices/camera-types.ts
@@ -39,9 +39,9 @@ export const CAMERA_DEFAULT_CONSTRAINTS = {
 };
 
 export interface CameraDevice {
-    index: number;
+    index: string;
     deviceId: string;
-    cameraId: string; // Camera ID is the last 5 characters of the device ID
+    cameraId: number;
     status: string;
     groupId: string;
     kind: string;
@@ -53,7 +53,7 @@ export interface CameraDevice {
 
 
 // Helper function
-export const createDefaultCameraConfig = (index: number, label: string, id: string): CameraConfig => ({
+export const createDefaultCameraConfig = (index: string, label: string, id: number): CameraConfig => ({
     camera_index: index,
     camera_name: label || `Camera ${index}`,
     camera_id: id || `camera-${index}`,

--- a/skellycam-ui/src/store/slices/cameras-slices/camera-types.ts
+++ b/skellycam-ui/src/store/slices/cameras-slices/camera-types.ts
@@ -39,9 +39,9 @@ export const CAMERA_DEFAULT_CONSTRAINTS = {
 };
 
 export interface CameraDevice {
-    index: string;
+    index: number;
     deviceId: string;
-    cameraId: number;
+    cameraId: string;
     status: string;
     groupId: string;
     kind: string;

--- a/skellycam-ui/src/store/slices/cameras-slices/camera-types.ts
+++ b/skellycam-ui/src/store/slices/cameras-slices/camera-types.ts
@@ -53,10 +53,10 @@ export interface CameraDevice {
 
 
 // Helper function
-export const createDefaultCameraConfig = (index: string, label: string, id: number): CameraConfig => ({
+export const createDefaultCameraConfig = (index: number, label: string, id: string): CameraConfig => ({
     camera_index: index,
     camera_name: label || `Camera ${index}`,
-    camera_id: id || `camera-${index}`,
+    camera_id: id,
     use_this_camera: true,
     resolution: CAMERA_DEFAULT_CONSTRAINTS.resolution.default,
     color_channels: 3,

--- a/skellycam-ui/src/store/thunks/detect-cameras-server-thunk.ts
+++ b/skellycam-ui/src/store/thunks/detect-cameras-server-thunk.ts
@@ -1,0 +1,84 @@
+import {createAsyncThunk} from "@reduxjs/toolkit";
+import {
+    setError,
+    setLoading,
+    setAvailableCameras,
+    setCameraStatus
+} from "@/store/slices/cameras-slices/camerasSlice";
+import {
+    CAMERA_DEFAULT_CONSTRAINTS,
+    CameraDevice,
+    createDefaultCameraConfig
+} from "@/store/slices/cameras-slices/camera-types";
+import { urlService } from "@/services/urlService";
+import {RootState} from "@/store/AppStateStore";
+
+export const detectCameraDevices = createAsyncThunk<
+    CameraDevice[]
+    >('cameras/detectServer',
+    async (args, { dispatch, getState }) => {
+        const filterVirtual = true;
+        dispatch(setLoading(true));
+
+        try {
+            const connectUrl = urlService.getCameraUrls().detectCameras;
+
+            console.log(`Detecting cameras at ${connectUrl}`);
+            const response = await fetch('${connectUrl}?filter_virtual=${filterVirtual}');
+
+            const data = await response.json();
+            const serverCameras = data.cameras;
+
+            // Convert server cameras to CameraDevice objects
+            const validatedCameras: CameraDevice[] = [];
+            const state = getState() as RootState;
+            const existingCameras = state.cameras.cameras;
+
+            Object.keys(existingCameras).forEach(cameraId => {
+                const stillExists = serverCameras.some(device => device.index === parseInt(cameraId));
+                if (!stillExists) {
+                    dispatch(setCameraStatus({ cameraId, status: 'UNAVAILABLE' }));
+                }
+            });
+
+            for (const serverCamera of serverCameras) {                
+                const existingCamera = existingCameras[serverCamera.index];
+                const newCamera: CameraDevice = {
+                    index: serverCamera.index,
+                    deviceId: serverCamera.vendor_id?.toString() + serverCamera.product_id?.toString(),
+                    cameraId: serverCamera.index,
+                    selected: existingCamera?.selected ?? false,
+                    status: 'AVAILABLE', // TODO: do we want to validate the cameras again?
+                    label: serverCamera.name,
+                    groupId: '', // TODO: not sure if this needs to be passed form the server?
+                    kind: 'videoinput',
+                    constraints: CAMERA_DEFAULT_CONSTRAINTS,
+                    config: existingCamera?.config || 
+                    createDefaultCameraConfig(
+                        serverCamera.index,
+                        serverCamera.name,
+                        serverCamera.index
+                    )
+                };
+
+                validatedCameras.push(newCamera);
+            }
+
+            console.log(`After validation, ${validatedCameras.length} camera(s) processed`, validatedCameras);
+            dispatch(setAvailableCameras(validatedCameras));
+            dispatch(setError(null));
+            return validatedCameras;
+        } catch (error) {
+            // Handle network errors and JSON parsing errors
+            const errorMessage = error instanceof Error
+                ? `Failed to detect cameras: ${error.message}`
+                : 'Failed to detect cameras: Unknown error';
+
+            dispatch(setError(errorMessage));
+            console.error(errorMessage, error);
+            throw error;
+        } finally {
+            dispatch(setLoading(false));
+        }
+    }
+);

--- a/skellycam-ui/src/store/thunks/detect-cameras-server-thunk.ts
+++ b/skellycam-ui/src/store/thunks/detect-cameras-server-thunk.ts
@@ -63,7 +63,7 @@ export const detectCameraDevices = createAsyncThunk<
                     createDefaultCameraConfig(
                         serverCamera.index,
                         serverCamera.name,
-                        serverCamera.index
+                        serverCamera.index.toString()
                     )
                 };
 

--- a/skellycam-ui/src/store/thunks/detect-cameras-server-thunk.ts
+++ b/skellycam-ui/src/store/thunks/detect-cameras-server-thunk.ts
@@ -24,7 +24,13 @@ export const detectCameraDevices = createAsyncThunk<
             const connectUrl = urlService.getCameraUrls().detectCameras;
 
             console.log(`Detecting cameras at ${connectUrl}`);
-            const response = await fetch('${connectUrl}?filter_virtual=${filterVirtual}');
+            const response = await fetch(connectUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ filterVirtual }),
+            });
 
             const data = await response.json();
             const serverCameras = data.cameras;

--- a/skellycam-ui/vite.config.ts
+++ b/skellycam-ui/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ command }) => {
   return {
     resolve: {
       alias: {
-        '@': path.join(__dirname, 'src')
+        '@': path.resolve(__dirname, 'src')
       },
     },
     plugins: [

--- a/skellycam-ui/vite.config.ts
+++ b/skellycam-ui/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ command }) => {
   return {
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, 'src')
+        '@': path.join(__dirname, 'src')
       },
     },
     plugins: [

--- a/skellycam/api/http/cameras/camera_router.py
+++ b/skellycam/api/http/cameras/camera_router.py
@@ -57,7 +57,7 @@ class DetectedCamerasResponse(BaseModel):
 @camera_router.get("/detect",
                    summary="Detect available camera devices",
                    )
-def cameras_detect_get_endpoint(filter_virtual: bool = True,
+def cameras_detect_endpoint(filter_virtual: bool = True,
                                 backend_id: CameraBackendInt | None = None) -> DetectedCamerasResponse:
     logger.api(f"Received `skellycam/cameras/detect` POST request with filter_virtual={filter_virtual}...")
     try:

--- a/skellycam/api/http/cameras/camera_router.py
+++ b/skellycam/api/http/cameras/camera_router.py
@@ -54,7 +54,7 @@ class DetectedCamerasResponse(BaseModel):
     cameras: list[CameraDeviceInfo]
 
 
-@camera_router.get("/detect",
+@camera_router.post("/detect",
                    summary="Detect available camera devices",
                    )
 def cameras_detect_endpoint(filter_virtual: bool = True,

--- a/skellycam/core/camera/config/camera_config.py
+++ b/skellycam/core/camera/config/camera_config.py
@@ -52,19 +52,19 @@ def get_video_file_type(fourcc_code: int) -> str:
     '.mp4'
     """
     fourcc_to_extension = {
-        cv2.VideoWriter_fourcc(*'MP4V'): 'mp4',
-        cv2.VideoWriter_fourcc(*'H264'): 'mp4',
-        cv2.VideoWriter_fourcc(*'X264'): 'mp4',
+        cv2.VideoWriter.fourcc(*'MP4V'): 'mp4',
+        cv2.VideoWriter.fourcc(*'H264'): 'mp4',
+        cv2.VideoWriter.fourcc(*'X264'): 'mp4',
 
-        cv2.VideoWriter_fourcc(*'XVID'): 'avi',
-        cv2.VideoWriter_fourcc(*'DIVX'): 'avi',
+        cv2.VideoWriter.fourcc(*'XVID'): 'avi',
+        cv2.VideoWriter.fourcc(*'DIVX'): 'avi',
 
-        cv2.VideoWriter_fourcc(*'MJPG'): 'mjpeg',
-        cv2.VideoWriter_fourcc(*'VP80'): 'webm',
-        cv2.VideoWriter_fourcc(*'THEO'): 'ogv',
-        cv2.VideoWriter_fourcc(*'WMV1'): 'wmv',
-        cv2.VideoWriter_fourcc(*'WMV2'): 'wmv',
-        cv2.VideoWriter_fourcc(*'FLV1'): 'flv',
+        cv2.VideoWriter.fourcc(*'MJPG'): 'mjpeg',
+        cv2.VideoWriter.fourcc(*'VP80'): 'webm',
+        cv2.VideoWriter.fourcc(*'THEO'): 'ogv',
+        cv2.VideoWriter.fourcc(*'WMV1'): 'wmv',
+        cv2.VideoWriter.fourcc(*'WMV2'): 'wmv',
+        cv2.VideoWriter.fourcc(*'FLV1'): 'flv',
     }
 
     file_format = fourcc_to_extension.get(fourcc_code, None)

--- a/skellycam/core/camera/opencv/extract_config.py
+++ b/skellycam/core/camera/opencv/extract_config.py
@@ -1,4 +1,5 @@
 import logging
+from sys import platform
 
 import cv2
 
@@ -22,7 +23,12 @@ def extract_config_from_cv2_capture(camera_index: CameraIndexInt,
     exposure = int(cv2_capture.get(cv2.CAP_PROP_EXPOSURE))
     framerate = cv2_capture.get(cv2.CAP_PROP_FPS)
 
-    if any([width == 0, height == 0, exposure == 0, framerate == 0]):
+    if any([
+        width == 0, 
+        height == 0, 
+        framerate == 0,
+        not (platform == "darwin") and exposure == 0  # macOS always returns 0 for exposure
+    ]):
         logger.error(f"Failed to extract configuration from cv2.VideoCapture object - "
                      f"width: {width}, height: {height}, exposure: {exposure}, framerate: {framerate}")
         raise ValueError("Invalid camera configuration detected. Please check the camera settings.")

--- a/skellycam/core/ipc/pubsub/pubsub_abcs.py
+++ b/skellycam/core/ipc/pubsub/pubsub_abcs.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC
 from multiprocessing.process import parent_process
+from sys import platform
 from typing import Type
 
 import numpy as np
@@ -48,7 +49,8 @@ class PubSubTopicABC(BaseModel, ABC):
         if len(self.subscriptions) == 0:
             logger.warning(f"Publishing message of type {self.message_type} with no subscribers, message will be lost")
             return
-        logger.trace(f"Publishing message of type {self.message_type} to {len(self.subscriptions)} subscribers with ~{np.mean([sub.qsize() for sub in self.subscriptions]):.2f} messages per subscriber")
+        if platform != "darwin":  # no qsize attribute on macOS
+            logger.trace(f"Publishing message of type {self.message_type} to {len(self.subscriptions)} subscribers with ~{np.mean([sub.qsize() for sub in self.subscriptions]):.2f} messages per subscriber")
         for sub in self.subscriptions:
             if overwrite:
                 overwrote = 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,15 +1,16 @@
 version = 1
+revision = 1
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
-    "python_full_version < '3.11' and platform_system == 'Darwin'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system != 'Darwin') or (python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux')",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system != 'Darwin') or (python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux')",
-    "python_full_version >= '3.12' and platform_system == 'Darwin'",
-    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and platform_system != 'Darwin') or (python_full_version >= '3.12' and platform_system != 'Darwin' and platform_system != 'Linux')",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
 [[package]]
@@ -71,7 +72,7 @@ name = "build"
 version = "1.2.2.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "colorama", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
@@ -157,7 +158,7 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
 wheels = [
@@ -178,7 +179,7 @@ name = "cv2-enumerate-cameras"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-framework-avfoundation", marker = "platform_system == 'Darwin'" },
+    { name = "pyobjc-framework-avfoundation", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e9/1ed371073498f6a4be7cf32dd19605e7fa067497328668a1083e85a3ae71/cv2_enumerate_cameras-1.2.2.tar.gz", hash = "sha256:7dce1335605a4d19fc402c2b3b7d45d5bd80143c20b77be3655f96f30ad76510", size = 11942 }
 wheels = [
@@ -670,11 +671,11 @@ name = "pyobjc-framework-avfoundation"
 version = "11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-coreaudio", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-coremedia", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "platform_system == 'Darwin'" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreaudio", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coremedia", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/1f/90cdbce1d3b4861cbb17c12adf57daeec32477eb1df8d3f9ab8551bdadfb/pyobjc_framework_avfoundation-11.1.tar.gz", hash = "sha256:6663056cc6ca49af8de6d36a7fff498f51e1a9a7f1bde7afba718a8ceaaa7377", size = 832178 }
 wheels = [
@@ -688,7 +689,7 @@ name = "pyobjc-framework-cocoa"
 version = "11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "platform_system == 'Darwin'" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/c5/7a866d24bc026f79239b74d05e2cf3088b03263da66d53d1b4cf5207f5ae/pyobjc_framework_cocoa-11.1.tar.gz", hash = "sha256:87df76b9b73e7ca699a828ff112564b59251bb9bbe72e610e670a4dc9940d038", size = 5565335 }
 wheels = [
@@ -702,8 +703,8 @@ name = "pyobjc-framework-coreaudio"
 version = "11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "platform_system == 'Darwin'" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/c0/4ab6005cf97e534725b0c14b110d4864b367c282b1c5b0d8f42aad74a83f/pyobjc_framework_coreaudio-11.1.tar.gz", hash = "sha256:b7b89540ae7efc6c1e3208ac838ef2acfc4d2c506dd629d91f6b3b3120e55c1b", size = 141032 }
 wheels = [
@@ -717,8 +718,8 @@ name = "pyobjc-framework-coremedia"
 version = "11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "platform_system == 'Darwin'" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/5d/81513acd219df77a89176f1574d936b81ad6f6002225cabb64d55efb7e8d/pyobjc_framework_coremedia-11.1.tar.gz", hash = "sha256:82cdc087f61e21b761e677ea618a575d4c0dbe00e98230bf9cea540cff931db3", size = 216389 }
 wheels = [
@@ -732,8 +733,8 @@ name = "pyobjc-framework-quartz"
 version = "11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "platform_system == 'Darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "platform_system == 'Darwin'" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/ac/6308fec6c9ffeda9942fef72724f4094c6df4933560f512e63eac37ebd30/pyobjc_framework_quartz-11.1.tar.gz", hash = "sha256:a57f35ccfc22ad48c87c5932818e583777ff7276605fef6afad0ac0741169f75", size = 3953275 }
 wheels = [
@@ -887,7 +888,6 @@ wheels = [
 
 [[package]]
 name = "skellycam"
-version = "2023.9.1086"
 source = { editable = "." }
 dependencies = [
     { name = "cv2-enumerate-cameras" },
@@ -953,6 +953,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.30.6" },
     { name = "websockets", specifier = ">=13.1" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1063,7 +1064,7 @@ name = "tzlocal"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761 }
 wheels = [


### PR DESCRIPTION
Replace the client side camera detection using mediaDevices to the server side using `cv2_enumerate_cameras`.

This correctly detects the cameras and connects to them. There are issues with the display and recording, but those may or may not have been present before (it wouldn't run before on mac, so I can't test). 

<img width="1271" height="712" alt="Screenshot 2025-07-10 at 4 09 24 PM" src="https://github.com/user-attachments/assets/ebb612e7-08b1-4c0f-bcdd-803b450a16de" />


## Problems

1. I might have messed up the client side config. I got a little lost between the `id`, `index`, `name`, etc. Double check that what I do matches the intended semantics.
2. Sometimes it just crashes. It's happened once while the cameras were just running (`RuntimeError: Failed to grab frame from camera 1`) but also if I try to reconnect to the cameras
3. The display is a little laggy. I don't think this is due to any of my changes but keep it in mind for testing.
4. Same for recording - it records, but the display lags even more, and the resulting videos is sped up - probably not all the frames are being saved properly. Again this may not be a regression, but keep it in mind for testing.
5. The color and exposure are very weird. It appears to be worse on the frontend than the backend - the one camera may just appear more blue, but the other two are clearly displaying differently than they are recording.
6. I had to add a `zod` dependency that was keeping me from starting the frontend

## TODO:

- [ ] actually deal with the `filterVirtual` flag - I removed it to eliminate a variable while debugging
- [x] test on mac
- [ ] test on windows
- [ ] test on linux