### PR TITLE
Improved server management ux

### DIFF
--- a/skellycam-ui/electron/main/services/python-server.ts
+++ b/skellycam-ui/electron/main/services/python-server.ts
@@ -52,11 +52,13 @@ export class PythonServer {
 
             pythonProcess.on('exit', (code) => {
                 console.log(`Python server exited (code: ${code})`);
+                pythonProcess = null;
                 this.currentExecutablePath = null;
             });
 
             pythonProcess.on('error', (error) => {
                 console.error('Python server process error:', error);
+                pythonProcess = null;
                 this.currentExecutablePath = null;
             });
 

--- a/skellycam-ui/src/components/ServerConnectionStatus.tsx
+++ b/skellycam-ui/src/components/ServerConnectionStatus.tsx
@@ -91,6 +91,7 @@ export const ServerConnectionStatus: React.FC = () => {
     // Transient state
     const [serverRunning, setServerRunning] = useState(false);
     const [serverReachable, setServerReachable] = useState(false);
+    const [initialStatusChecked, setInitialStatusChecked] = useState(false);
     const [serverLoading, setServerLoading] = useState(false);
     const [currentExePath, setCurrentExePath] = useState<string | null>(null);
     const [candidates, setCandidates] = useState<ExecutableCandidate[]>([]);
@@ -140,6 +141,7 @@ export const ServerConnectionStatus: React.FC = () => {
         } catch {
             setServerReachable(false);
         }
+        setInitialStatusChecked(true);
     }, [isElectron, api]);
 
     // ── Candidate management ──
@@ -280,12 +282,13 @@ export const ServerConnectionStatus: React.FC = () => {
         if (!autoLaunchServer) return;
         if (autoLaunchFiredRef.current) return;
         if (candidatesLoading) return; // wait for candidates to load
+        if (!initialStatusChecked) return; // wait for first health check to complete
         if (serverRunning || serverReachable || serverLoading) return;
 
         autoLaunchFiredRef.current = true;
         console.log('Auto-launching server...');
         startServer();
-    }, [isElectron, api, autoLaunchServer, candidatesLoading, serverRunning, serverLoading, startServer]);
+    }, [isElectron, api, autoLaunchServer, candidatesLoading, initialStatusChecked, serverRunning, serverReachable, serverLoading, startServer]);
 
     // ── WebSocket auto-reconnect loop ──
     // When autoConnectWs is on and we're not connected, periodically call connect().

--- a/skellycam-ui/src/components/ServerConnectionStatus.tsx
+++ b/skellycam-ui/src/components/ServerConnectionStatus.tsx
@@ -281,8 +281,8 @@ export const ServerConnectionStatus: React.FC = () => {
     }, [isElectron, api, autoLaunchServer, candidatesLoading, serverRunning, serverLoading, startServer]);
 
     // ── WebSocket auto-reconnect loop ──
-    // Tries up to MAX_WS_CONNECT_ATTEMPTS times then stops and shows disconnected.
-    // Resets when the user manually connects, disconnects, or a connection succeeds.
+    // After MAX_WS_CONNECT_ATTEMPTS failures the UI shows "connection failed", but
+    // retrying continues in the background. A successful connection resets everything.
 
     const MAX_WS_CONNECT_ATTEMPTS = 15;
 
@@ -297,7 +297,6 @@ export const ServerConnectionStatus: React.FC = () => {
             setWsConnectionGaveUp(false);
             return;
         }
-        if (wsConnectionGaveUp) return;
 
         connect();
         wsFailedAttemptsRef.current++;
@@ -305,14 +304,13 @@ export const ServerConnectionStatus: React.FC = () => {
         const interval = setInterval(() => {
             if (wsFailedAttemptsRef.current >= MAX_WS_CONNECT_ATTEMPTS) {
                 setWsConnectionGaveUp(true);
-                return;
             }
             connect();
             wsFailedAttemptsRef.current++;
         }, WS_RECONNECT_INTERVAL_MS);
 
         return () => clearInterval(interval);
-    }, [autoConnectWs, isConnected, wsConnectionGaveUp, connect]);
+    }, [autoConnectWs, isConnected, connect]);
 
     // ── Toggle handlers ──
 
@@ -429,7 +427,7 @@ export const ServerConnectionStatus: React.FC = () => {
                         variant="caption"
                         sx={{ fontWeight: 500, color: wsStatusColor, whiteSpace: 'nowrap', fontSize: '0.7rem' }}
                     >
-                        {isConnected ? t('connected') : isConnecting ? t('connecting') : autoConnectWs ? t('disconnected') : t('off')}
+                        {isConnected ? t('connected') : isConnecting ? t('connecting') : wsConnectionGaveUp ? t('connectionFailed') : autoConnectWs ? t('disconnected') : t('off')}
                     </Typography>
 
                     {isElectron && (
@@ -765,7 +763,7 @@ export const ServerConnectionStatus: React.FC = () => {
                                 />
                             )}
                             <Typography variant="caption" sx={{ color: theme.palette.text.primary, flex: 1 }}>
-                                {isConnected ? t('connected') : isConnecting ? t('connecting') : t('disconnected')}
+                                {isConnected ? t('connected') : isConnecting ? t('connecting') : wsConnectionGaveUp ? t('connectionFailed') : t('disconnected')}
                                 {isConnected && connectedCameraIds.length > 0
                                     ? ` — ${connectedCameraIds.length} camera${connectedCameraIds.length !== 1 ? 's' : ''}`
                                     : ''}

--- a/skellycam-ui/src/components/ServerConnectionStatus.tsx
+++ b/skellycam-ui/src/components/ServerConnectionStatus.tsx
@@ -153,11 +153,11 @@ export const ServerConnectionStatus: React.FC = () => {
             const result = await api.pythonServer.getExecutableCandidates.query();
             const typed = result as ExecutableCandidate[];
             setCandidates(typed);
-            if (!selectedExePath) {
+            const validPaths = new Set(typed.filter((c) => c.isValid).map((c) => c.path));
+            const currentIsValid = selectedExePath && validPaths.has(selectedExePath);
+            if (!currentIsValid) {
                 const firstValid = typed.find((c) => c.isValid);
-                if (firstValid) {
-                    setSelectedExePath(firstValid.path);
-                }
+                setSelectedExePath(firstValid?.path ?? '');
             }
         } catch (err) {
             console.error('Failed to load executable candidates:', err);

--- a/skellycam-ui/src/components/ServerConnectionStatus.tsx
+++ b/skellycam-ui/src/components/ServerConnectionStatus.tsx
@@ -29,7 +29,7 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import { useServer } from '@/services/server/ServerContextProvider';
 import { useTranslation } from "react-i18next";
 import { useElectronIPC } from '@/services';
-import { DEFAULT_HOST, DEFAULT_PORT } from '@/services/server/server-helpers/server-urls';
+import { DEFAULT_HOST, DEFAULT_PORT, serverUrls } from '@/services/server/server-helpers/server-urls';
 
 interface ExecutableCandidate {
     name: string;
@@ -90,6 +90,7 @@ export const ServerConnectionStatus: React.FC = () => {
 
     // Transient state
     const [serverRunning, setServerRunning] = useState(false);
+    const [serverReachable, setServerReachable] = useState(false);
     const [serverLoading, setServerLoading] = useState(false);
     const [currentExePath, setCurrentExePath] = useState<string | null>(null);
     const [candidates, setCandidates] = useState<ExecutableCandidate[]>([]);
@@ -132,6 +133,12 @@ export const ServerConnectionStatus: React.FC = () => {
             setCurrentExePath(exePath);
         } catch (err) {
             console.error('Failed to poll server status:', err);
+        }
+        try {
+            const res = await fetch(serverUrls.endpoints.health, { signal: AbortSignal.timeout(2000) });
+            setServerReachable(res.ok);
+        } catch {
+            setServerReachable(false);
         }
     }, [isElectron, api]);
 
@@ -273,7 +280,7 @@ export const ServerConnectionStatus: React.FC = () => {
         if (!autoLaunchServer) return;
         if (autoLaunchFiredRef.current) return;
         if (candidatesLoading) return; // wait for candidates to load
-        if (serverRunning || serverLoading) return;
+        if (serverRunning || serverReachable || serverLoading) return;
 
         autoLaunchFiredRef.current = true;
         console.log('Auto-launching server...');
@@ -281,10 +288,12 @@ export const ServerConnectionStatus: React.FC = () => {
     }, [isElectron, api, autoLaunchServer, candidatesLoading, serverRunning, serverLoading, startServer]);
 
     // ── WebSocket auto-reconnect loop ──
+    // When autoConnectWs is on and we're not connected, periodically call connect().
+    // The underlying WebSocketConnection handles deduplication of CONNECTING state.
     // After MAX_WS_CONNECT_ATTEMPTS failures the UI shows "connection failed", but
     // retrying continues in the background. A successful connection resets everything.
 
-    const MAX_WS_CONNECT_ATTEMPTS = 15;
+    const MAX_WS_CONNECT_ATTEMPTS = 5;
 
     useEffect(() => {
         if (!autoConnectWs) {
@@ -375,7 +384,8 @@ export const ServerConnectionStatus: React.FC = () => {
 
     const isConnecting = autoConnectWs && !isConnected && !wsConnectionGaveUp;
     const wsStatusColor = isConnected ? '#00ffff' : isConnecting ? '#ffb300' : '#f44336';
-    const serverStatusColor = serverRunning ? theme.palette.success.main : theme.palette.text.disabled;
+    const serverIsExternal = serverReachable && !serverRunning;
+    const serverStatusColor = (serverRunning || serverReachable) ? theme.palette.success.main : theme.palette.text.disabled;
 
     const validCandidates = candidates.filter((c) => c.isValid);
     const invalidCandidates = candidates.filter((c) => !c.isValid);
@@ -456,7 +466,7 @@ export const ServerConnectionStatus: React.FC = () => {
                                 variant="caption"
                                 sx={{ fontWeight: 500, color: serverStatusColor, whiteSpace: 'nowrap', fontSize: '0.7rem' }}
                             >
-                                {serverLoading ? t('working') : serverRunning ? t('running') : t('stopped')}
+                                {serverLoading ? t('working') : serverRunning ? t('running') : serverIsExternal ? t('runningExternal') : t('stopped')}
                             </Typography>
                         </>
                     )}
@@ -522,14 +532,14 @@ export const ServerConnectionStatus: React.FC = () => {
                                         width: 8,
                                         height: 8,
                                         borderRadius: '50%',
-                                        backgroundColor: serverRunning
+                                        backgroundColor: (serverRunning || serverReachable)
                                             ? theme.palette.success.main
                                             : theme.palette.error.main,
                                     }}
                                 />
                                 <Typography variant="caption" sx={{ color: theme.palette.text.primary }}>
-                                    {serverRunning ? t('running') : t('stopped')}
-                                    {processInfo?.pid && ` (PID: ${processInfo.pid})`}
+                                    {serverRunning ? t('running') : serverIsExternal ? t('runningExternal') : t('stopped')}
+                                    {serverRunning && processInfo?.pid && ` (PID: ${processInfo.pid})`}
                                 </Typography>
                             </Box>
 
@@ -540,7 +550,7 @@ export const ServerConnectionStatus: React.FC = () => {
                                     value={selectedExePath}
                                     onChange={(e) => setSelectedExePath(e.target.value)}
                                     label={t("executable")}
-                                    disabled={serverRunning || serverLoading}
+                                    disabled={serverRunning || serverReachable || serverLoading}
                                     sx={{ fontSize: '0.75rem' }}
                                 >
                                     {validCandidates.map((candidate) => (
@@ -594,7 +604,7 @@ export const ServerConnectionStatus: React.FC = () => {
                                     <IconButton
                                         size="small"
                                         onClick={browseForExecutable}
-                                        disabled={serverRunning || serverLoading}
+                                        disabled={serverRunning || serverReachable || serverLoading}
                                         sx={{ border: `1px solid ${theme.palette.divider}`, borderRadius: 1 }}
                                     >
                                         <FolderOpenIcon sx={{ fontSize: 16 }} />
@@ -604,7 +614,7 @@ export const ServerConnectionStatus: React.FC = () => {
                                     <IconButton
                                         size="small"
                                         onClick={refreshCandidates}
-                                        disabled={serverRunning || candidatesLoading}
+                                        disabled={serverRunning || serverReachable || candidatesLoading}
                                         sx={{ border: `1px solid ${theme.palette.divider}`, borderRadius: 1 }}
                                     >
                                         {candidatesLoading ? (
@@ -624,7 +634,7 @@ export const ServerConnectionStatus: React.FC = () => {
                                     color="success"
                                     startIcon={serverLoading ? <CircularProgress size={14} color="inherit" /> : <PlayArrowIcon />}
                                     onClick={() => startServer()}
-                                    disabled={serverRunning || serverLoading}
+                                    disabled={serverRunning || serverReachable || serverLoading}
                                     sx={{ flex: 1, fontSize: '0.7rem', textTransform: 'none' }}
                                 >
                                     Launch

--- a/skellycam-ui/src/components/ServerConnectionStatus.tsx
+++ b/skellycam-ui/src/components/ServerConnectionStatus.tsx
@@ -101,6 +101,9 @@ export const ServerConnectionStatus: React.FC = () => {
     const autoLaunchFiredRef = useRef(false);
     // Guard against concurrent startServer calls from the auto-launch effect
     const serverLaunchingRef = useRef(false);
+    // Count consecutive failed WS connection attempts so we can stop spinning after giving up
+    const wsFailedAttemptsRef = useRef(0);
+    const [wsConnectionGaveUp, setWsConnectionGaveUp] = useState(false);
 
     // ── Persistence effects ──
 
@@ -278,24 +281,38 @@ export const ServerConnectionStatus: React.FC = () => {
     }, [isElectron, api, autoLaunchServer, candidatesLoading, serverRunning, serverLoading, startServer]);
 
     // ── WebSocket auto-reconnect loop ──
-    // When autoConnectWs is on and we're not connected, periodically call connect().
-    // The underlying WebSocketConnection handles deduplication of CONNECTING state.
+    // Tries up to MAX_WS_CONNECT_ATTEMPTS times then stops and shows disconnected.
+    // Resets when the user manually connects, disconnects, or a connection succeeds.
+
+    const MAX_WS_CONNECT_ATTEMPTS = 15;
 
     useEffect(() => {
-        if (!autoConnectWs) return;
-        if (isConnected) return;
+        if (!autoConnectWs) {
+            wsFailedAttemptsRef.current = 0;
+            setWsConnectionGaveUp(false);
+            return;
+        }
+        if (isConnected) {
+            wsFailedAttemptsRef.current = 0;
+            setWsConnectionGaveUp(false);
+            return;
+        }
+        if (wsConnectionGaveUp) return;
 
-        // Fire one immediate attempt
         connect();
+        wsFailedAttemptsRef.current++;
 
         const interval = setInterval(() => {
-            if (!isConnected) {
-                connect();
+            if (wsFailedAttemptsRef.current >= MAX_WS_CONNECT_ATTEMPTS) {
+                setWsConnectionGaveUp(true);
+                return;
             }
+            connect();
+            wsFailedAttemptsRef.current++;
         }, WS_RECONNECT_INTERVAL_MS);
 
         return () => clearInterval(interval);
-    }, [autoConnectWs, isConnected, connect]);
+    }, [autoConnectWs, isConnected, wsConnectionGaveUp, connect]);
 
     // ── Toggle handlers ──
 
@@ -332,6 +349,8 @@ export const ServerConnectionStatus: React.FC = () => {
             setAutoConnectWs(false);
             disconnect();
         } else {
+            wsFailedAttemptsRef.current = 0;
+            setWsConnectionGaveUp(false);
             setAutoConnectWs(true);
             connect();
         }
@@ -356,7 +375,8 @@ export const ServerConnectionStatus: React.FC = () => {
 
     // ── Derived values ──
 
-    const wsStatusColor = isConnected ? '#00ffff' : '#f44336';
+    const isConnecting = autoConnectWs && !isConnected && !wsConnectionGaveUp;
+    const wsStatusColor = isConnected ? '#00ffff' : isConnecting ? '#ffb300' : '#f44336';
     const serverStatusColor = serverRunning ? theme.palette.success.main : theme.palette.text.disabled;
 
     const validCandidates = candidates.filter((c) => c.isValid);
@@ -397,6 +417,8 @@ export const ServerConnectionStatus: React.FC = () => {
                         >
                             {isConnected ? (
                                 <WifiIcon sx={{ fontSize: 16 }} />
+                            ) : isConnecting ? (
+                                <CircularProgress size={14} sx={{ color: wsStatusColor }} />
                             ) : (
                                 <WifiOffIcon sx={{ fontSize: 16 }} />
                             )}
@@ -407,7 +429,7 @@ export const ServerConnectionStatus: React.FC = () => {
                         variant="caption"
                         sx={{ fontWeight: 500, color: wsStatusColor, whiteSpace: 'nowrap', fontSize: '0.7rem' }}
                     >
-                        {isConnected ? t('connected') : autoConnectWs ? t('connecting') : t('off')}
+                        {isConnected ? t('connected') : isConnecting ? t('connecting') : autoConnectWs ? t('disconnected') : t('off')}
                     </Typography>
 
                     {isElectron && (
@@ -730,16 +752,20 @@ export const ServerConnectionStatus: React.FC = () => {
                         </Box>
 
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <Box
-                                sx={{
-                                    width: 8,
-                                    height: 8,
-                                    borderRadius: '50%',
-                                    backgroundColor: isConnected ? '#00ffff' : theme.palette.error.main,
-                                }}
-                            />
+                            {isConnecting ? (
+                                <CircularProgress size={8} sx={{ color: wsStatusColor }} />
+                            ) : (
+                                <Box
+                                    sx={{
+                                        width: 8,
+                                        height: 8,
+                                        borderRadius: '50%',
+                                        backgroundColor: isConnected ? '#00ffff' : theme.palette.error.main,
+                                    }}
+                                />
+                            )}
                             <Typography variant="caption" sx={{ color: theme.palette.text.primary, flex: 1 }}>
-                                {isConnected ? t('connected') : autoConnectWs ? t('connecting') : t('disconnected')}
+                                {isConnected ? t('connected') : isConnecting ? t('connecting') : t('disconnected')}
                                 {isConnected && connectedCameraIds.length > 0
                                     ? ` — ${connectedCameraIds.length} camera${connectedCameraIds.length !== 1 ? 's' : ''}`
                                     : ''}

--- a/skellycam-ui/src/components/camera-config-tree-view/CameraConfigTreeViewHeader.tsx
+++ b/skellycam-ui/src/components/camera-config-tree-view/CameraConfigTreeViewHeader.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/store/slices/cameras/cameras-thunks";
 import {savedSettingsCleared} from "@/store/slices/cameras/cameras-slice";
 import {useTranslation} from 'react-i18next';
+import {useServer} from "@/services/server/ServerContextProvider";
 
 interface CameraConfigTreeViewHeaderProps {
     cameraCount: number;
@@ -34,6 +35,7 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
     const theme = useTheme();
     const dispatch = useAppDispatch();
     const {t} = useTranslation();
+    const {isConnected} = useServer();
     const selectedCameras = useAppSelector(selectSelectedCameras);
     const hasSelected = selectedCameras.length > 0;
 
@@ -119,11 +121,12 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
 
             <Stack direction="row" spacing={1} sx={{mr: 2}}>
                 {/* Connect/Apply Button - Always visible, changes icon and behavior */}
-                <Tooltip title={t("connectCameras")}>
+                <Tooltip title={t(!isConnected ? "connectServerFirst" : "connectCameras")}>
                     <span>
                         <IconButton
                             size="small"
                             onClick={handleConnectOrApply}
+                            disabled={!isConnected || isActionInProgress}
                             sx={{color: "inherit"}}
                         >
 
@@ -184,11 +187,12 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                 </Tooltip>
 
                 {/* Refresh/Detect Button - Always visible */}
-                <Tooltip title={t("detectCameras")}>
+                <Tooltip title={t(!isConnected ? "connectServerFirst" : "detectCameras")}>
                     <span>
                         <IconButton
                             size="small"
                             onClick={handleRefreshCameras}
+                            disabled={!isConnected || isActionInProgress}
                             sx={{color: "inherit"}}
                         >
                             {isLoading || isActionInProgress ? (

--- a/skellycam-ui/src/components/camera-config-tree-view/CameraConfigTreeViewHeader.tsx
+++ b/skellycam-ui/src/components/camera-config-tree-view/CameraConfigTreeViewHeader.tsx
@@ -128,7 +128,7 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                             size="small"
                             onClick={handleConnectOrApply}
                             disabled={!isConnected || isActionInProgress}
-                            sx={{color: "inherit"}}
+                            sx={{color: "inherit", "&.Mui-disabled": {opacity: 0.5}}}
                         >
 
                         <Box sx={{position: 'relative', display: 'inline-flex', width: 24, height: 24}}>
@@ -164,9 +164,7 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                             size="small"
                             onClick={handlePauseUnpause}
                             disabled={!hasCamerasConnected || isActionInProgress}
-                            sx={{
-                                color: "inherit",
-                            }}
+                            sx={{color: "inherit", "&.Mui-disabled": {opacity: 0.5}}}
                         >
                             {isPaused ? <PlayArrowIcon/> : <PauseIcon/>}
                         </IconButton>
@@ -180,9 +178,7 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                             size="small"
                             onClick={handleCloseCameras}
                             disabled={!hasCamerasConnected || isActionInProgress}
-                            sx={{
-                                color: "inherit",
-                            }}
+                            sx={{color: "inherit", "&.Mui-disabled": {opacity: 0.5}}}
                         >
                             <VideocamOffIcon/>
                         </IconButton>
@@ -196,7 +192,7 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                             size="small"
                             onClick={handleRefreshCameras}
                             disabled={!isConnected || isActionInProgress}
-                            sx={{color: "inherit"}}
+                            sx={{color: "inherit", "&.Mui-disabled": {opacity: 0.5}}}
                         >
                             {isLoading || isActionInProgress ? (
                                 <CircularProgress size={20} sx={{color: "inherit"}}/>

--- a/skellycam-ui/src/components/camera-config-tree-view/CameraConfigTreeViewHeader.tsx
+++ b/skellycam-ui/src/components/camera-config-tree-view/CameraConfigTreeViewHeader.tsx
@@ -35,7 +35,8 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
     const theme = useTheme();
     const dispatch = useAppDispatch();
     const {t} = useTranslation();
-    const {isConnected} = useServer();
+    const {isConnected, connectedCameraIds} = useServer();
+    const hasCamerasConnected = connectedCameraIds.length > 0;
     const selectedCameras = useAppSelector(selectSelectedCameras);
     const hasSelected = selectedCameras.length > 0;
 
@@ -156,12 +157,13 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                     </span>
                 </Tooltip>
 
-                {/* Pause/Play Button - Always visible, disabled when not connected */}
+                {/* Pause/Play Button - Always visible, disabled when no cameras connected */}
                 <Tooltip title={isPaused ? t("resumeStreaming") : t("pauseStreaming")}>
                     <span>
                         <IconButton
                             size="small"
                             onClick={handlePauseUnpause}
+                            disabled={!hasCamerasConnected || isActionInProgress}
                             sx={{
                                 color: "inherit",
                             }}
@@ -171,12 +173,13 @@ export const CameraConfigTreeViewHeader: React.FC<CameraConfigTreeViewHeaderProp
                     </span>
                 </Tooltip>
 
-                {/* Close Button - Always visible, disabled when not connected */}
+                {/* Close Button - Always visible, disabled when no cameras connected */}
                 <Tooltip title={t("closeAllCameras")}>
                     <span>
                         <IconButton
                             size="small"
                             onClick={handleCloseCameras}
+                            disabled={!hasCamerasConnected || isActionInProgress}
                             sx={{
                                 color: "inherit",
                             }}

--- a/skellycam-ui/src/components/recording-info-panel/RecordingInfoPanel.tsx
+++ b/skellycam-ui/src/components/recording-info-panel/RecordingInfoPanel.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from "react";
-import {Box, Typography, useTheme} from "@mui/material";
+import {Box, Tooltip, Typography, useTheme} from "@mui/material";
+import {useTranslation} from "react-i18next";
 import {SimpleTreeView} from "@mui/x-tree-view/SimpleTreeView";
 import {TreeItem} from "@mui/x-tree-view/TreeItem";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -26,6 +27,7 @@ interface RecordingOperation {
 
 export const RecordingInfoPanel: React.FC = () => {
     const theme = useTheme();
+    const {t} = useTranslation();
     const dispatch = useAppDispatch();
     const recordingInfo = useAppSelector(
         (state) => state.recording
@@ -50,7 +52,7 @@ export const RecordingInfoPanel: React.FC = () => {
     const [recordingTag, setRecordingTag] = useState<string>("");
     const [micDeviceIndex, setMicDeviceIndex] = useState<number>(-1);
     const {isElectron, api} = useElectronIPC();
-    const {connectedCameraIds} = useServer();
+    const {connectedCameraIds, isConnected} = useServer();
     const noCamerasConnected = connectedCameraIds.length === 0;
 
     // Track when recording state changes to clear pending state
@@ -249,14 +251,18 @@ export const RecordingInfoPanel: React.FC = () => {
                             </Typography>
 
                             <Box onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} sx={{ flexGrow: 1, ml: 1.5 }}>
-                                <StartStopRecordingButton
-                                    isRecording={recordingInfo.isRecording}
-                                    isPending={pendingOperation !== null}
-                                    countdown={countdown}
-                                    recordingStartTime={recordingStartTime}
-                                    disabled={noCamerasConnected && !recordingInfo.isRecording}
-                                    onClick={handleRecordButtonClick}
-                                />
+                                <Tooltip title={(!isConnected || noCamerasConnected) && !recordingInfo.isRecording ? t('connectCamerasBeforeRecording') : ''}>
+                                    <span>
+                                        <StartStopRecordingButton
+                                            isRecording={recordingInfo.isRecording}
+                                            isPending={pendingOperation !== null}
+                                            countdown={countdown}
+                                            recordingStartTime={recordingStartTime}
+                                            disabled={(!isConnected || noCamerasConnected) && !recordingInfo.isRecording}
+                                            onClick={handleRecordButtonClick}
+                                        />
+                                    </span>
+                                </Tooltip>
                             </Box>
                         </Box>
                     }

--- a/skellycam-ui/src/i18n/locales/en-english.json
+++ b/skellycam-ui/src/i18n/locales/en-english.json
@@ -163,6 +163,7 @@
   "connect": "Connect",
   "off": "Off",
   "running": "Running",
+  "runningExternal": "Running (external)",
   "stopped": "Stopped",
   "working": "Working…",
   "invalid": "Invalid",

--- a/skellycam-ui/src/i18n/locales/en-english.json
+++ b/skellycam-ui/src/i18n/locales/en-english.json
@@ -158,6 +158,8 @@
   "connected": "Connected",
   "connecting": "Connecting…",
   "connectionFailed": "Connection failed",
+  "connectServerFirst": "Must connect to server before connecting to cameras",
+  "connectCamerasBeforeRecording": "Connect to cameras before recording",
   "disconnected": "Disconnected",
   "disconnect": "Disconnect",
   "connect": "Connect",

--- a/skellycam-ui/src/i18n/locales/en-english.json
+++ b/skellycam-ui/src/i18n/locales/en-english.json
@@ -157,6 +157,7 @@
   "videoLoadingSettings": "Video Loading Settings",
   "connected": "Connected",
   "connecting": "Connecting…",
+  "connectionFailed": "Connection failed",
   "disconnected": "Disconnected",
   "disconnect": "Disconnect",
   "connect": "Connect",

--- a/skellycam-ui/src/pages/WelcomePage.tsx
+++ b/skellycam-ui/src/pages/WelcomePage.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState, useRef, useCallback} from 'react';
 import {
     Box, Button, Checkbox, CircularProgress, Container,
-    darken, Divider, Fade, FormControlLabel, Grow, Paper, Stack, Typography
+    darken, Divider, Fade, FormControlLabel, Grow, Paper, Stack, Tooltip, Typography
 } from '@mui/material';
 import {useNavigate} from 'react-router-dom';
 import {useTheme} from '@mui/material/styles';
@@ -25,7 +25,7 @@ const WelcomePage: React.FC = () => {
     const [telemetryEnabled, setTelemetryEnabled] = useState<boolean>(true);
     const [telemetryLoaded, setTelemetryLoaded] = useState<boolean>(false);
     const {isElectron, api} = useElectronIPC();
-    const {connectedCameraIds} = useServer();
+    const {connectedCameraIds, isConnected} = useServer();
     const dispatch = useAppDispatch();
     const [isConnecting, setIsConnecting] = useState(false);
 
@@ -212,6 +212,8 @@ const WelcomePage: React.FC = () => {
 
                     {/* ── PRIMARY CTA ── */}
                     <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', mb: 2 }}>
+                        <Tooltip title={!isConnected ? t('connectServerFirst') : ''}>
+                            <span style={{ width: '100%', maxWidth: 400, display: 'flex', justifyContent: 'center' }}>
                         <Button
                             variant="contained"
                             size="large"
@@ -220,7 +222,7 @@ const WelcomePage: React.FC = () => {
                                 : <VideocamIcon sx={{ fontSize: 28 }} />
                             }
                             onClick={handleConnectCameras}
-                            disabled={isConnecting}
+                            disabled={isConnecting || !isConnected}
                             sx={{
                                 '&&': {
                                     px: 6,
@@ -250,6 +252,8 @@ const WelcomePage: React.FC = () => {
                         >
                             {t('connectToCameras')}
                         </Button>
+                            </span>
+                        </Tooltip>
                     </Box>
 
                     {/* ── SECONDARY LINKS ── */}

--- a/skellycam-ui/src/services/server/ServerContextProvider.tsx
+++ b/skellycam-ui/src/services/server/ServerContextProvider.tsx
@@ -10,6 +10,7 @@ import {LogStore, LogRecord} from "@/services/server/server-helpers/log-store";
 
 interface ServerContextValue {
     isConnected: boolean;
+    connectionState: ConnectionState;
     connect: () => void;
     disconnect: () => void;
     send: (data: string | object) => void;
@@ -69,6 +70,7 @@ function isFramerateUpdate(data: any): data is FramerateUpdateMessage {
 export const ServerContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     // Reactive state - only updates when camera list actually changes
     const [isConnected, setIsConnected] = useState<boolean>(false);
+    const [connectionState, setConnectionState] = useState<ConnectionState>(ConnectionState.DISCONNECTED);
     const [connectedCameraIds, setConnectedCameraIds] = useState<string[]>([]);
 
     // Service instances
@@ -128,6 +130,7 @@ export const ServerContextProvider: React.FC<{ children: ReactNode }> = ({ child
         const handleStateChange = (newState: ConnectionState): void => {
             const connected = newState === ConnectionState.CONNECTED;
             setIsConnected(connected);
+            setConnectionState(newState);
 
             if (newState === ConnectionState.DISCONNECTED || newState === ConnectionState.FAILED) {
                 canvasManagerRef.current?.terminateAllWorkers();
@@ -312,6 +315,7 @@ export const ServerContextProvider: React.FC<{ children: ReactNode }> = ({ child
 
     const contextValue = useMemo(() => ({
         isConnected,
+        connectionState,
         connect,
         disconnect,
         send,
@@ -322,7 +326,7 @@ export const ServerContextProvider: React.FC<{ children: ReactNode }> = ({ child
         getLogStore,
         connectedCameraIds,
         updateServerConnection,
-    }), [isConnected, connectedCameraIds, connect, disconnect, send, setCanvasForCamera, getFps, getServerFps, getFramerateStore, getLogStore, updateServerConnection]);
+    }), [isConnected, connectionState, connectedCameraIds, connect, disconnect, send, setCanvasForCamera, getFps, getServerFps, getFramerateStore, getLogStore, updateServerConnection]);
 
     return (
         <ServerContext.Provider value={contextValue}>

--- a/skellycam/core/camera_group/camera_group.py
+++ b/skellycam/core/camera_group/camera_group.py
@@ -304,6 +304,10 @@ async def await_extracted_configs(
             ] = extracted_config_message.extracted_config
         await await_100ms()
 
+    failed = [cam_id for cam_id, config in updated_configs.items() if not isinstance(config, CameraConfig)]
+    if failed:
+        raise RuntimeError(f"Failed to initialize camera(s): {failed}")
+
     validate_camera_configs(updated_configs)
 
     return updated_configs

--- a/uv.lock
+++ b/uv.lock
@@ -1410,7 +1410,7 @@ wheels = [
 
 [[package]]
 name = "skellycam"
-version = "2.0.0a4"
+version = "2.0.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Trying to improve the user experience around the server management. This includes better feedback about the current state, and better communication between the frontend and backend about the state.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other

### Changes:

- [x] Spinning indicator when trying to connect to websocket, goes to failed after 15 attempted connections (frontend still tries to connect intermittently under the hood, so if connection happens it responds automatically)

<img width="408" height="410" alt="Screenshot 2026-05-04 at 3 28 01 PM" src="https://github.com/user-attachments/assets/aaf6b1d0-3ffc-43e4-a254-b3db45dd19db" />

- [x] Run `/health` check in `pollServerStatus` to find external servers (running outside of electron). This prevents autolaunching the server if there's one running, and prevents the "no server started" dialogue when there is a server running. Downside is frequent API calls clogging up the logs - we could have a "silent health check" endpoint if this is a problem?

<img width="418" height="343" alt="Screenshot 2026-05-04 at 3 27 46 PM" src="https://github.com/user-attachments/assets/c0be56ef-541f-46db-bf51-18c75fce0b92" />

- [x] Made the Connect to cameras and start recording buttons disabled when the server is disconnected. Both have tooltips explaining why they're disconnected. Also fixed the pause and close camera buttons to be disabled when there is no camera group connected - the comment said this was the behavior but it was not, so this just aligns it with the commented behavior

- [x] Check the default executable path in local storage and make sure its valid before loading. If invalid, search through valid paths again. Right now, if you change executable paths (been working in dev, go to electron, or vice versa) and the old path is no longer valid, the server will try to open that path and then fail. Then it will not auto open the other paths. This now checks the stored path, and refinds if it isn't valid. This got auto launching working properly for me.