### PR TITLE
Reset playback state when loading recordings

### DIFF
--- a/skellycam-ui/src/components/playback/SyncedVideoPlayer.tsx
+++ b/skellycam-ui/src/components/playback/SyncedVideoPlayer.tsx
@@ -256,6 +256,25 @@ export const SyncedVideoPlayer: React.FC<SyncedVideoPlayerProps> = ({ videos, re
         leaderIdRef.current = videos.length > 0 ? videos[0].videoId : null;
     }, [videos]);
 
+    // Reset all frame state when the set of videos changes (new recording loaded)
+    const videoKey = videos.map((v) => v.videoId).join(',');
+    useEffect(() => {
+        if (rafRef.current !== null) {
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        }
+        isPlayingRef.current = false;
+        currentFrameRef.current = 0;
+        totalFramesRef.current = 0;
+        didSeekInitialRef.current = false;
+        setIsPlaying(false);
+        setCurrentFrame(0);
+        setTotalFrames(0);
+        setDuration(0);
+        setVideosReady(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [videoKey]);
+
     // -----------------------------------------------------------------------
     // Direct DOM overlay updates — fast, no React involved
     // -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The playback state was persisting between loading different recordings. This meant the frame limit was limited to the lowest framerate recording loaded yet. This is fixed by resetting all the playback state when loading a new recording.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
