### PR TITLE
Stream camera recordings to disk with bounded memory

### DIFF
--- a/skellycam/gui/qt/workers/camera_group_thread_worker.py
+++ b/skellycam/gui/qt/workers/camera_group_thread_worker.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from copy import deepcopy
+from pathlib import Path
 from typing import List, Union
 
 import cv2
@@ -14,6 +14,7 @@ from skellycam.gui.qt.workers.video_save_thread_worker import VideoSaveThreadWor
 from skellycam.opencv.camera.types.camera_id import CameraId
 from skellycam.opencv.group.camera_group import CameraGroup
 from skellycam.opencv.video_recorder.video_recorder import VideoRecorder
+from skellycam.opencv.video_recorder.streaming_video_writer import WriterFailedError, WriterSaturatedError
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,20 @@ class CamGroupThreadWorker(QThread):
         self._updating_camera_settings_bool = False
         self._current_recording_name = None
         self._video_save_process = None
+
+        # Global synchronized frame index. Assigned once per committed
+        # multi-camera frame bundle (see run()), not per camera -- this is
+        # what lets every camera's writer agree on the same frame identity
+        # without needing every frame resident in RAM for post-hoc matching.
+        self._next_frame_index = 0
+
+        # Real-time approximation of the old post-hoc nearest-timestamp
+        # match, applied per-bundle instead of across a full in-RAM buffer.
+        # Deliberately NOT proven equivalent for multi-camera use -- see
+        # _try_record_synchronized_frame_bundle()'s docstring. 50ms is a
+        # provisional default (roughly 1.5 frame periods at 30fps); tune
+        # after real multi-camera jitter is measured.
+        self._max_frame_bundle_timestamp_delta_ns = 50_000_000
 
         self._charuco_board = charuco_7x5()
 
@@ -127,13 +142,13 @@ class CamGroupThreadWorker(QThread):
                 continue
 
             frame_payload_dictionary = self._camera_group.latest_frames()
+
+            if self._should_record_frames_bool and not self._should_pause_bool:
+                self._try_record_synchronized_frame_bundle(frame_payload_dictionary)
+
             for camera_id, frame_payload in frame_payload_dictionary.items():
                 if frame_payload:
                     if not self._should_pause_bool:
-                        if self._should_record_frames_bool:
-                            self._video_recorder_dictionary[camera_id].append_frame_payload_to_list(frame_payload)
-                            logger.info(f"camera:frame_count - {self._get_recorder_frame_count_dict()}")
-
                         if self.annotate_images:
                             draw_charuco_on_image(image=frame_payload.image, charuco_board=self.charuco_board)
 
@@ -153,6 +168,94 @@ class CamGroupThreadWorker(QThread):
                             logger.error(f"Error getting frame count for camera {camera_id}: {e}")
 
                         self.new_image_signal.emit(camera_id, q_image, frame_diagnostic_dictionary)
+
+    def _try_record_synchronized_frame_bundle(self, frame_payload_dictionary: dict) -> None:
+        """Commit one synchronized frame bundle per poll iteration: either
+        every enabled camera's writer receives this iteration's frame under
+        the same global frame_index, or none of them do.
+
+        IMPORTANT (see ARCHITECTURE_REPORT.md / STREAMING_RECORDING_ARCHITECTURE.md
+        for the full analysis): CameraGroup.latest_frames() is a per-camera
+        independent queue pop with NO cross-camera timestamp comparison --
+        the capture-loop poll was never a synchronization boundary in the
+        original design. The original algorithm synchronized post-hoc, at
+        save time, via nearest-timestamp matching across each camera's full
+        in-RAM buffer -- which this rewrite deliberately removes (that's the
+        memory bug). "Same poll iteration" alone is therefore NOT equivalent
+        to that original guarantee: a backlogged frame from a slow camera
+        could otherwise be paired with a fresh frame from a fast one under
+        the same frame_index. The max-timestamp-delta check below is a
+        real-time approximation of the same intent, not a proven-equivalent
+        replacement -- multi-camera correctness under this design is
+        deliberately treated as IMPROVED BUT UNVALIDATED, not proven, and a
+        dedicated multi-camera synchronization test is required before this
+        is trusted for real multi-camera recordings. This incident and this
+        sprint's live testing are single-camera only, where this distinction
+        does not apply (there is nothing to pair against).
+        """
+        # Stable order owned by the worker (dict insertion order, set once by
+        # _initialize_video_recorder_dictionary) -- iterating a set directly
+        # gives non-deterministic order, which makes failure-ordering
+        # unreproducible for no benefit.
+        camera_ids_in_order = list(self._video_recorder_dictionary.keys())
+        expected_camera_ids = set(camera_ids_in_order)
+        available_camera_ids = {
+            camera_id for camera_id, payload in frame_payload_dictionary.items() if payload
+        }
+        if not expected_camera_ids.issubset(available_camera_ids):
+            return  # partial bundle this iteration -- wait for the next one, never commit it
+
+        if len(camera_ids_in_order) > 1:
+            timestamps_ns = [
+                frame_payload_dictionary[camera_id].timestamp_ns for camera_id in camera_ids_in_order
+            ]
+            max_delta_ns = max(timestamps_ns) - min(timestamps_ns)
+            if max_delta_ns > self._max_frame_bundle_timestamp_delta_ns:
+                logger.debug(
+                    "Skipping frame bundle -- cameras not sufficiently synchronized this "
+                    f"iteration (max_delta_ns={max_delta_ns} > "
+                    f"threshold={self._max_frame_bundle_timestamp_delta_ns}). This is an "
+                    "expected, non-fatal skip under multi-camera jitter, not a failure."
+                )
+                return  # not a synchronized instant -- skip, never commit it under a shared index
+
+        frame_index = self._next_frame_index
+        self._next_frame_index += 1
+
+        submitted_camera_ids = []
+        try:
+            for camera_id in camera_ids_in_order:
+                self._video_recorder_dictionary[camera_id].append_frame_payload_to_list(
+                    frame_payload_dictionary[camera_id], frame_index=frame_index,
+                )
+                submitted_camera_ids.append(camera_id)
+        except (WriterSaturatedError, WriterFailedError) as exc:
+            logger.error(
+                f"Recording writer failure at frame_index={frame_index} "
+                f"({len(submitted_camera_ids)}/{len(camera_ids_in_order)} cameras already "
+                f"committed this frame before the failure): {exc}"
+            )
+            self._abort_recording(reason=str(exc))
+
+    def _abort_recording(self, reason: str) -> None:
+        """Honest failure path for queue saturation or writer death: every
+        camera's writer is aborted together so the recording never claims
+        partial success. Partial files are preserved by StreamingVideoWriter;
+        this method just makes sure nothing keeps submitting to a doomed
+        recording and that a fresh, empty set of recorders is ready for the
+        next Start."""
+        logger.error(f"Aborting synchronized recording: {reason}")
+        self._should_record_frames_bool = False
+        for camera_id, video_recorder in self._video_recorder_dictionary.items():
+            if video_recorder.is_streaming:
+                try:
+                    video_recorder.abort_streaming(reason=reason)
+                except RuntimeError:
+                    pass  # already finished (e.g. this was the camera whose failure triggered the abort)
+                except Exception as exc:  # noqa: BLE001
+                    logger.error(f"Error aborting recorder for camera {camera_id}: {exc}")
+        self._synchronized_video_folder_path = None
+        self._video_recorder_dictionary = self._initialize_video_recorder_dictionary()
 
     def _convert_frame(self, frame: FramePayload):
         image = frame.image
@@ -188,6 +291,20 @@ class CamGroupThreadWorker(QThread):
         if self.cameras_connected:
             if self._synchronized_video_folder_path is None:
                 self._synchronized_video_folder_path = self._get_new_synchronized_videos_folder_callable()
+
+            # Writer opened here, at Start, not deferred to Stop -- this is
+            # what makes recording duration stop determining RAM usage.
+            self._next_frame_index = 0
+            for camera_id, video_recorder in self._video_recorder_dictionary.items():
+                config = self._camera_group.camera_config_dictionary[camera_id]
+                output_path = Path(self._synchronized_video_folder_path) / (
+                    f"Camera_{str(camera_id).zfill(3)}_synchronized.mp4"
+                )
+                video_recorder.start_streaming(
+                    video_file_save_path=output_path,
+                    expected_fps=float(config.framerate),
+                )
+
             self._should_record_frames_bool = True
         else:
             logger.warning("Cannot start recording - cameras not connected")
@@ -195,11 +312,7 @@ class CamGroupThreadWorker(QThread):
     def stop_recording(self):
         logger.info("Stopping recording")
         self._should_record_frames_bool = False
-
         self._launch_save_video_thread_worker()
-        # self._launch_save_video_process()
-        del self._video_recorder_dictionary
-        self._video_recorder_dictionary = self._initialize_video_recorder_dictionary()
 
     def update_camera_group_configs(self, camera_config_dictionary: dict):
         if self._camera_ids is None:
@@ -224,10 +337,24 @@ class CamGroupThreadWorker(QThread):
         synchronized_videos_folder = self._synchronized_video_folder_path
         self._synchronized_video_folder_path = None
 
-        video_recorders_to_save = {}
-        for camera_id, video_recorder in self._video_recorder_dictionary.items():
-            if video_recorder.number_of_frames > 0:
-                video_recorders_to_save[camera_id] = deepcopy(video_recorder)
+        # Ownership transfer, not deepcopy: hand the already-streaming
+        # recorders (writer handles, bounded queues, small metadata -- no
+        # frame image data) straight to the background finalize worker, and
+        # immediately give the capture path a fresh, empty set of recorders
+        # for the next recording. This removes the Stop-time doubling of the
+        # frame buffer that was the acute trigger of the original freeze --
+        # see ARCHITECTURE_REPORT.md.
+        video_recorders_to_save = {
+            camera_id: video_recorder
+            for camera_id, video_recorder in self._video_recorder_dictionary.items()
+            if video_recorder.is_streaming
+        }
+        self._video_recorder_dictionary = self._initialize_video_recorder_dictionary()
+
+        if not video_recorders_to_save:
+            logger.warning("No active recorders to save -- nothing was recorded")
+            self.videos_saved_to_this_folder_signal.emit(str(synchronized_videos_folder))
+            return
 
         self._video_save_thread_worker = VideoSaveThreadWorker(
             dictionary_of_video_recorders=video_recorders_to_save,

--- a/skellycam/opencv/video_recorder/save_synchronized_videos.py
+++ b/skellycam/opencv/video_recorder/save_synchronized_videos.py
@@ -1,15 +1,10 @@
 import logging
 import platform
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, Union
 
-import numpy as np
-
-from skellycam.detection.models.frame_payload import FramePayload
-from skellycam.diagnostics.create_diagnostic_plots import create_diagnostic_plots
+from skellycam.opencv.video_recorder.streaming_video_writer import StreamingWriterResult
 from skellycam.opencv.video_recorder.video_recorder import VideoRecorder
-from skellycam.tests.test_frame_timestamp_synchronization import test_frame_timestamp_synchronization
-from skellycam.tests.test_synchronized_video_frame_counts import test_synchronized_video_frame_counts
 
 logger = logging.getLogger(__name__)
 
@@ -18,115 +13,59 @@ def save_synchronized_videos(
         dictionary_of_video_recorders: Dict[str, VideoRecorder],
         folder_to_save_videos: Union[str, Path],
         create_diagnostic_plots_bool: bool = True,
-):
-    logger.info(f"Saving synchronized videos to folder: {str(folder_to_save_videos)}")
+        stop_timeout_seconds: float = 10.0,
+) -> Dict[str, StreamingWriterResult]:
+    """Finalizes an already-streamed synchronized recording.
 
-    each_cam_raw_frame_list = []
-    first_frame_timestamps = []
-    final_frame_timestamps = []
+    Historically this function held every camera's full raw-frame list in
+    RAM simultaneously, clipped/matched them by nearest timestamp, and only
+    then wrote anything to disk -- the root cause this rewrite exists to fix
+    (see ARCHITECTURE_REPORT.md). Frames are now written to disk during
+    capture by each camera's own StreamingVideoWriter (bounded queue, opened
+    at recording Start -- see video_recorder.py / camera_group_thread_worker.py).
+    Cross-camera synchronization now happens per-frame at capture time
+    (camera_group_thread_worker._try_record_synchronized_frame_bundle):
+    every enabled camera either writes the same global frame_index, or the
+    whole recording is aborted -- so by the time this function runs, frame
+    counts across cameras should already match by construction.
 
-    for video_recoder in dictionary_of_video_recorders.values():
-        camera_frame_list = video_recoder.frame_payload_list
-        first_frame_timestamps.append(camera_frame_list[0].timestamp_ns)
-        final_frame_timestamps.append(camera_frame_list[-1].timestamp_ns)
+    This function's only remaining job is to drain each camera's writer,
+    validate that every camera actually finished cleanly with matching frame
+    counts, and report an honest result. It never holds frame image data.
+    """
+    logger.info(f"Finalizing synchronized recording in folder: {str(folder_to_save_videos)}")
 
-        each_cam_raw_frame_list.append(camera_frame_list)
+    results: Dict[str, StreamingWriterResult] = {}
+    for camera_id, video_recorder in dictionary_of_video_recorders.items():
+        results[camera_id] = video_recorder.stop_streaming(timeout_seconds=stop_timeout_seconds)
 
-    latest_first_frame = np.max(first_frame_timestamps)
-    earliest_final_frame = np.min(final_frame_timestamps)
+    frame_counts = {camera_id: result.frames_written for camera_id, result in results.items()}
+    logger.info(f"Frames written per camera: {frame_counts}")
 
-    logger.info(f"first_frame_timestamps: {first_frame_timestamps}")
-    logger.info(f"np.diff(first_frame_timestamps): {np.diff(first_frame_timestamps)}")
-    logger.info(f"latest_first_frame: {latest_first_frame}")
+    all_succeeded = all(result.success for result in results.values())
+    distinct_counts = set(frame_counts.values())
+    counts_match = len(distinct_counts) <= 1
 
-    logger.info(f"final_frame_timestamps: {final_frame_timestamps}")
-    logger.info(f"np.diff(final_frame_timestamps): {np.diff(final_frame_timestamps)}")
-    logger.info(f"earliest_final_frame: {earliest_final_frame}")
-
-    logger.info(f"----")
-    logger.info(
-        f"Clipping each camera's frame list to latest first frame and earliest final frame"
-    )
-    each_cam_clipped_frame_list = []
-    each_cam_clipped_timestamp_list = []
-    for og_frame_list in each_cam_raw_frame_list:
-        each_cam_clipped_frame_list.append([])
-        each_cam_clipped_timestamp_list.append([])
-        for frame in og_frame_list:
-            if frame.timestamp_ns < latest_first_frame:
-                continue
-            if frame.timestamp_ns > earliest_final_frame:
-                continue
-
-            each_cam_clipped_frame_list[-1].append(frame)
-            each_cam_clipped_timestamp_list[-1].append(frame.timestamp_ns)
-
-    number_of_frames_per_camera_clipped = [len(f) for f in each_cam_clipped_frame_list]
-    min_number_of_frames = np.min(number_of_frames_per_camera_clipped)
-    index_of_the_camera_with_fewest_frames = np.argmin(
-        number_of_frames_per_camera_clipped
-    )
-
-    reference_frame_list = each_cam_clipped_frame_list[
-        index_of_the_camera_with_fewest_frames
-    ]
-    logger.info(
-        f" (clipped) number_of_frames_per_camera: {number_of_frames_per_camera_clipped}, min:{min_number_of_frames}"
-    )
-    logger.info(
-        "Creating synchronized frame list by matching each camera's timestamps to the timestamps of the camera with the fewest frames"
-    )
-    logger.info(
-        "TODO - Make a reference timestamp list based on the desired/measured framerate (while ensuring we won't throw away good frames...)"
-    )
-    synchronized_frame_list_dictionary = {}
-    for camera_id, camera_frame_list in enumerate(each_cam_clipped_frame_list):
-        logger.info(f"Creating synchronized frame list for camera {camera_id}...")
-        cam_synchronized_frame_list = []
-        for reference_frame in reference_frame_list:
-            closest_frame = get_nearest_frame(camera_frame_list, reference_frame)
-            cam_synchronized_frame_list.append(closest_frame)
-        synchronized_frame_list_dictionary[str(camera_id)] = cam_synchronized_frame_list
-
-    test_frame_timestamp_synchronization(synchronized_frame_list_dictionary=synchronized_frame_list_dictionary)
-
-    Path(folder_to_save_videos).mkdir(parents=True, exist_ok=True)
-    for camera_id, frame_list in synchronized_frame_list_dictionary.items():
-        logger.info(
-            f" Saving camera {camera_id} video with {len(frame_list)} frames..."
+    if not all_succeeded or not counts_match:
+        failed_cameras = [camera_id for camera_id, result in results.items() if not result.success]
+        logger.error(
+            "Synchronized recording did NOT finalize cleanly -- "
+            f"all_succeeded={all_succeeded} counts_match={counts_match} "
+            f"frame_counts={frame_counts} failed_cameras={failed_cameras}. "
+            "Partial/.failure.json files are preserved on disk for inspection; "
+            "no camera's output was marked complete/renamed unless it "
+            "individually succeeded."
         )
-        VideoRecorder().save_frame_list_to_video_file(
-            frame_payload_list=frame_list,
-            video_file_save_path=Path(folder_to_save_videos)
-                                 / f"Camera_{str(camera_id).zfill(3)}_synchronized.mp4",
+        return results
+
+    logger.info(f"Synchronized recording finalized successfully: {frame_counts}")
+
+    if platform.system() == "Windows" and create_diagnostic_plots_bool:
+        logger.warning(
+            "Diagnostic plots are not available with the streaming recorder "
+            "(they required the previous full in-RAM frame buffer, which no "
+            "longer exists by design). Skipped -- see "
+            "docs/STREAMING_RECORDING_FAILURE_RECOVERY.md."
         )
 
-    test_synchronized_video_frame_counts(video_folder_path=folder_to_save_videos)
-
-    if not platform.system() == "Windows":
-        logger.info("Non-Windows system detected, diagnostic plots for webcams will not be displayed")
-        logger.info(f"Done!")
-        return
-        
-    if create_diagnostic_plots_bool:
-        create_diagnostic_plots(
-            video_recorder_dictionary=dictionary_of_video_recorders,
-            synchronized_frame_list_dictionary=synchronized_frame_list_dictionary,
-            folder_to_save_plots=folder_to_save_videos,
-            show_plots_bool=True,
-        )
-
-    logger.info(f"Done!")
-
-
-def get_nearest_frame(frame_list, reference_frame) -> FramePayload:
-    timestamps = gather_timestamps(frame_list)
-
-    close_frame_index = np.argmin(np.abs(timestamps - reference_frame.timestamp_ns))
-
-    return frame_list[close_frame_index]
-
-
-def gather_timestamps(frame_list: List[FramePayload]) -> np.ndarray:
-    timestamps = [frame.timestamp_ns for frame in frame_list]
-    return np.array(timestamps)
+    return results

--- a/skellycam/opencv/video_recorder/streaming_video_writer.py
+++ b/skellycam/opencv/video_recorder/streaming_video_writer.py
@@ -1,0 +1,343 @@
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Protocol, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_QUEUE_CAPACITY = 60  # ~2 seconds of buffering at 30fps, documented per-camera capacity
+DEFAULT_SUBMIT_TIMEOUT_SECONDS = 0.5
+DEFAULT_STOP_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class StreamingFramePacket:
+    frame_index: int
+    camera_id: str
+    timestamp_ns: int
+    image: np.ndarray
+
+
+@dataclass(frozen=True)
+class StreamingWriterResult:
+    success: bool
+    frames_submitted: int
+    frames_written: int
+    peak_queue_depth: int
+    output_path: Optional[Path]
+    partial_path: Optional[Path]
+    error: Optional[str] = None
+
+
+class WriterSaturatedError(RuntimeError):
+    """Raised when submit() cannot enqueue a frame within the allotted timeout.
+
+    This is the bounded-queue backpressure contract: a short wait is allowed,
+    but persistent saturation must fail loudly rather than silently drop
+    synchronized frames.
+    """
+
+
+class WriterFailedError(RuntimeError):
+    """Raised when submit() is called on a writer that has already failed."""
+
+
+class FrameEncoder(Protocol):
+    """Minimal interface a video encoder backend must satisfy. Lets tests
+    substitute a fake/no-op encoder so memory-regression tests don't need to
+    actually encode video."""
+
+    def open(self, path: Path, width: int, height: int, fps: float) -> bool: ...
+
+    def write(self, image: np.ndarray) -> None: ...
+
+    def release(self) -> None: ...
+
+
+class Cv2FrameEncoder:
+    """Default production encoder backend -- thin wrapper over cv2.VideoWriter,
+    matching the fourcc/container already used by the existing recorder."""
+
+    def __init__(self, fourcc: str = "mp4v"):
+        self._fourcc = fourcc
+        self._writer = None
+
+    def open(self, path: Path, width: int, height: int, fps: float) -> bool:
+        import cv2
+
+        self._writer = cv2.VideoWriter(
+            str(path),
+            cv2.VideoWriter_fourcc(*self._fourcc),
+            fps,
+            (int(width), int(height)),
+        )
+        return bool(self._writer.isOpened())
+
+    def write(self, image: np.ndarray) -> None:
+        self._writer.write(image)
+
+    def release(self) -> None:
+        if self._writer is not None:
+            self._writer.release()
+            self._writer = None
+
+
+class StreamingVideoWriter:
+    """Streams frames for a single camera to disk with bounded memory.
+
+    Contrasts with the previous architecture (VideoRecorder.frame_payload_list):
+    the encoder is opened at start(), a dedicated background thread drains a
+    FINITE queue continuously during capture, and no frame image is retained
+    once it has been written. Recording duration no longer determines RAM
+    usage -- only queue_capacity does.
+    """
+
+    def __init__(
+            self,
+            output_path: Union[str, Path],
+            expected_fps: float,
+            queue_capacity: int = DEFAULT_QUEUE_CAPACITY,
+            submit_timeout_seconds: float = DEFAULT_SUBMIT_TIMEOUT_SECONDS,
+            encoder: Optional[FrameEncoder] = None,
+    ):
+        self._final_path = Path(output_path)
+        self._partial_path = self._final_path.with_name(
+            self._final_path.stem + ".partial" + self._final_path.suffix
+        )
+        self._expected_fps = expected_fps
+        self._queue_capacity = queue_capacity
+        self._submit_timeout_seconds = submit_timeout_seconds
+        self._encoder = encoder or Cv2FrameEncoder()
+
+        self._queue: "queue.Queue[Optional[StreamingFramePacket]]" = queue.Queue(maxsize=queue_capacity)
+        self._writer_thread: Optional[threading.Thread] = None
+        self._timestamps: List[Tuple[int, int]] = []  # (frame_index, timestamp_ns) scalars only -- small
+        self._lock = threading.Lock()
+
+        self._started = False
+        self._finished = False
+        self._encoder_opened = False
+        self._frames_submitted = 0
+        self._frames_written = 0
+        self._peak_queue_depth = 0
+        self._failed = False
+        self._error: Optional[str] = None
+
+    # -- observable properties -------------------------------------------------
+    @property
+    def queue_capacity(self) -> int:
+        return self._queue_capacity
+
+    @property
+    def queue_depth(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def frames_submitted(self) -> int:
+        return self._frames_submitted
+
+    @property
+    def frames_written(self) -> int:
+        return self._frames_written
+
+    @property
+    def peak_queue_depth(self) -> int:
+        return self._peak_queue_depth
+
+    @property
+    def is_healthy(self) -> bool:
+        return not self._failed
+
+    @property
+    def final_path(self) -> Path:
+        return self._final_path
+
+    @property
+    def partial_path(self) -> Path:
+        return self._partial_path
+
+    # -- lifecycle -------------------------------------------------------
+    def start(self) -> None:
+        if self._started:
+            raise RuntimeError("StreamingVideoWriter already started")
+        self._partial_path.parent.mkdir(parents=True, exist_ok=True)
+        self._started = True
+        self._writer_thread = threading.Thread(
+            target=self._drain_loop,
+            name=f"StreamingVideoWriter-{self._final_path.name}",
+            daemon=True,
+        )
+        self._writer_thread.start()
+
+    def submit(self, packet: StreamingFramePacket, timeout_seconds: Optional[float] = None) -> None:
+        """Enqueue one frame. Raises WriterSaturatedError if the bounded queue
+        stays full past the timeout, and WriterFailedError if the writer has
+        already failed -- callers must treat both as "abort this synchronized
+        recording honestly," never as "drop this frame and continue."""
+        if not self._started:
+            raise RuntimeError("submit() called before start()")
+        if self._failed:
+            raise WriterFailedError(self._error or "writer previously failed")
+
+        timeout = self._submit_timeout_seconds if timeout_seconds is None else timeout_seconds
+        try:
+            self._queue.put(packet, timeout=timeout)
+        except queue.Full:
+            self._failed = True
+            self._error = f"writer queue saturated (capacity={self._queue_capacity})"
+            raise WriterSaturatedError(self._error)
+
+        with self._lock:
+            self._frames_submitted += 1
+            depth = self._queue.qsize()
+            if depth > self._peak_queue_depth:
+                self._peak_queue_depth = depth
+
+    def stop(self, timeout_seconds: float = DEFAULT_STOP_TIMEOUT_SECONDS) -> StreamingWriterResult:
+        return self._finish(timeout_seconds=timeout_seconds, abort=False)
+
+    def abort(self, reason: str, timeout_seconds: float = DEFAULT_STOP_TIMEOUT_SECONDS) -> StreamingWriterResult:
+        self._failed = True
+        self._error = reason
+        return self._finish(timeout_seconds=timeout_seconds, abort=True)
+
+    # -- internal ----------------------------------------------------------
+    def _finish(self, timeout_seconds: float, abort: bool) -> StreamingWriterResult:
+        if self._finished:
+            raise RuntimeError("StreamingVideoWriter.stop()/abort() already called")
+        self._finished = True
+
+        if not self._started:
+            return StreamingWriterResult(
+                success=False, frames_submitted=0, frames_written=0, peak_queue_depth=0,
+                output_path=None, partial_path=None, error="writer was never started",
+            )
+
+        try:
+            self._queue.put(None, timeout=timeout_seconds)  # sentinel: no more frames
+        except queue.Full:
+            self._failed = True
+            self._error = self._error or "queue full while stopping"
+
+        if self._writer_thread is not None:
+            self._writer_thread.join(timeout=timeout_seconds)
+            if self._writer_thread.is_alive():
+                self._failed = True
+                self._error = self._error or f"writer thread did not finish within {timeout_seconds}s"
+
+        success = (
+                not abort
+                and not self._failed
+                and self._frames_written > 0
+                and self._frames_written == self._frames_submitted
+        )
+
+        if success:
+            self._save_timestamps()
+            self._final_path.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(self._partial_path, self._final_path)  # atomic finalize
+            return StreamingWriterResult(
+                success=True,
+                frames_submitted=self._frames_submitted,
+                frames_written=self._frames_written,
+                peak_queue_depth=self._peak_queue_depth,
+                output_path=self._final_path,
+                partial_path=None,
+                error=None,
+            )
+
+        self._write_failure_metadata()
+        return StreamingWriterResult(
+            success=False,
+            frames_submitted=self._frames_submitted,
+            frames_written=self._frames_written,
+            peak_queue_depth=self._peak_queue_depth,
+            output_path=None,
+            partial_path=self._partial_path if self._partial_path.exists() else None,
+            error=self._error or "aborted",
+        )
+
+    def _drain_loop(self) -> None:
+        try:
+            while True:
+                packet = self._queue.get()
+                if packet is None:
+                    break
+                try:
+                    if not self._encoder_opened:
+                        opened = self._encoder.open(
+                            path=self._partial_path,
+                            width=packet.image.shape[1],
+                            height=packet.image.shape[0],
+                            fps=self._expected_fps,
+                        )
+                        if not opened:
+                            self._failed = True
+                            self._error = f"encoder failed to open for {self._partial_path}"
+                            continue
+                        self._encoder_opened = True
+
+                    self._encoder.write(packet.image)
+                    self._timestamps.append((packet.frame_index, packet.timestamp_ns))
+                    self._frames_written += 1
+                except Exception as exc:  # noqa: BLE001 -- must not crash the thread silently
+                    logger.error(f"StreamingVideoWriter failed writing frame {packet.frame_index}: {exc}")
+                    self._failed = True
+                    self._error = str(exc)
+                finally:
+                    # Without this, `packet` (and its full-resolution image)
+                    # stays alive in this stack frame for as long as the
+                    # thread is blocked on the *next* queue.get() -- bounded
+                    # (never grows), but not immediately GC-eligible either.
+                    # Explicitly drop it so a written frame is freed the
+                    # instant it's done, not "whenever the next one arrives."
+                    packet = None
+        finally:
+            if self._encoder_opened:
+                self._encoder.release()
+
+    def _save_timestamps(self) -> None:
+        """One-shot conversion of the small (frame_index, timestamp_ns) scalar
+        list into the existing npy/csv format -- O(n) single allocation, not
+        the previous np.append()-in-a-loop O(n^2) pattern. This list holds
+        16 bytes/frame (two Python ints per tuple, negligible even for a long
+        recording), never frame image data."""
+        if not self._timestamps:
+            return
+
+        timestamp_folder = self._final_path.parent / "timestamps"
+        timestamp_folder.mkdir(parents=True, exist_ok=True)
+        base = timestamp_folder / self._final_path.stem
+
+        timestamps_npy = np.array([ts for _, ts in self._timestamps], dtype=np.float64)
+
+        npy_path = str(base) + "_binary.npy"
+        np.save(npy_path, timestamps_npy)
+        logger.info(f"Saved timestamps to path: {npy_path}")
+
+        csv_path = str(base) + "_timestamps_human_readable.csv"
+        pd.DataFrame(timestamps_npy).to_csv(csv_path)
+        logger.info(f"Saved timestamps to path: {csv_path}")
+
+    def _write_failure_metadata(self) -> None:
+        if not self._partial_path.exists():
+            return
+        failure_path = self._partial_path.with_suffix(self._partial_path.suffix + ".failure.json")
+        try:
+            failure_path.write_text(json.dumps({
+                "error": self._error,
+                "frames_submitted": self._frames_submitted,
+                "frames_written": self._frames_written,
+                "peak_queue_depth": self._peak_queue_depth,
+                "written_at_unix_time": time.time(),
+            }, indent=2))
+        except OSError as exc:
+            logger.error(f"Could not write failure metadata for {self._partial_path}: {exc}")

--- a/skellycam/opencv/video_recorder/video_recorder.py
+++ b/skellycam/opencv/video_recorder/video_recorder.py
@@ -1,90 +1,151 @@
 import logging
 import traceback
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 import cv2
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
 from skellycam.detection.models.frame_payload import FramePayload
+from skellycam.opencv.video_recorder.streaming_video_writer import (
+    DEFAULT_QUEUE_CAPACITY,
+    StreamingFramePacket,
+    StreamingVideoWriter,
+    StreamingWriterResult,
+    WriterFailedError,
+    WriterSaturatedError,
+)
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "VideoRecorder",
+    "StreamingWriterResult",
+    "WriterFailedError",
+    "WriterSaturatedError",
+]
+
 
 class VideoRecorder:
-    def __init__(self):
+    """Per-camera recording handle.
 
-        self._cv2_video_writer = None
-        self._path_to_save_video_file = None
-        self._frame_payload_list: List[FramePayload] = []
-        self._timestamps_npy = np.empty(0)
+    Historically this class accumulated every captured frame in an unbounded
+    `_frame_payload_list` for the entire recording, then wrote them all out
+    (and was `deepcopy()`-ed in full, images included) at Stop. That is the
+    root cause this class was rewritten to fix -- see ARCHITECTURE_REPORT.md.
+
+    It now streams frames to disk via a bounded-queue `StreamingVideoWriter`,
+    opened at `start_streaming()` (recording Start), fed one frame at a time
+    by `append_frame_payload_to_list()` (kept under its historical name so
+    existing call sites don't need to change), and finalized by
+    `stop_streaming()` / `abort_streaming()` at Stop. No frame image is ever
+    retained by this class once it has been submitted to the writer.
+    """
+
+    def __init__(self):
+        self._streaming_writer: Optional[StreamingVideoWriter] = None
+        self._path_to_save_video_file: Optional[Path] = None
+
+    # -- new streaming lifecycle -------------------------------------------------
+    @property
+    def is_streaming(self) -> bool:
+        return self._streaming_writer is not None
 
     @property
-    def timestamps(self) -> np.ndarray:
-        return self._gather_timestamps(self._frame_payload_list)
+    def is_healthy(self) -> bool:
+        return self._streaming_writer is None or self._streaming_writer.is_healthy
+
+    def start_streaming(
+            self,
+            video_file_save_path: Union[str, Path],
+            expected_fps: float,
+            queue_capacity: int = DEFAULT_QUEUE_CAPACITY,
+    ) -> None:
+        if self._streaming_writer is not None:
+            raise RuntimeError("VideoRecorder already streaming -- call stop_streaming() first")
+
+        self._path_to_save_video_file = Path(video_file_save_path)
+        self._streaming_writer = StreamingVideoWriter(
+            output_path=self._path_to_save_video_file,
+            expected_fps=expected_fps,
+            queue_capacity=queue_capacity,
+        )
+        self._streaming_writer.start()
+
+    def stop_streaming(self, timeout_seconds: float = 10.0) -> StreamingWriterResult:
+        if self._streaming_writer is None:
+            raise RuntimeError("stop_streaming() called before start_streaming()")
+        return self._streaming_writer.stop(timeout_seconds=timeout_seconds)
+
+    def abort_streaming(self, reason: str, timeout_seconds: float = 10.0) -> StreamingWriterResult:
+        if self._streaming_writer is None:
+            raise RuntimeError("abort_streaming() called before start_streaming()")
+        return self._streaming_writer.abort(reason=reason, timeout_seconds=timeout_seconds)
 
     @property
     def number_of_frames(self) -> int:
-        return len(self._frame_payload_list)
+        """Frames *submitted* to the writer so far. Kept under its historical
+        name/shape for compatibility with existing diagnostic call sites."""
+        if self._streaming_writer is None:
+            return 0
+        return self._streaming_writer.frames_submitted
 
     @property
-    def frame_payload_list(self) -> List[FramePayload]:
-        return self._frame_payload_list
+    def peak_queue_depth(self) -> int:
+        if self._streaming_writer is None:
+            return 0
+        return self._streaming_writer.peak_queue_depth
 
-    def close(self):
-        self._cv2_video_writer.release()
+    def append_frame_payload_to_list(self, frame_payload: FramePayload, frame_index: int) -> None:
+        """Historical name, new behavior: submits directly to the bounded
+        streaming queue instead of appending to an unbounded in-RAM list.
 
-    def append_frame_payload_to_list(self, frame_payload: FramePayload):
-        self._frame_payload_list.append(frame_payload)
+        Raises WriterSaturatedError / WriterFailedError -- callers (the
+        capture loop) must treat either as grounds to abort the entire
+        synchronized recording honestly, not to silently drop this frame.
+        """
+        if self._streaming_writer is None:
+            raise RuntimeError("append_frame_payload_to_list() called before start_streaming()")
 
-    def save_frame_list_to_video_file(
-            self,
-            video_file_save_path: Union[str, Path],
-            frame_payload_list: List[FramePayload],
-            frames_per_second: float = None,
-    ):
-
-        if frames_per_second is None:
-            self._timestamps_npy = self._gather_timestamps(frame_payload_list)
-            try:
-                frames_per_second = (
-                        np.nanmedian((np.diff(self._timestamps_npy) ** -1)) * 1e9
-                )
-            except Exception as e:
-                logger.debug("Error calculating frames per second")
-                traceback.print_exc()
-                raise e
-
-        self._cv2_video_writer = self._initialize_video_writer(
-            image_height=frame_payload_list[0].image.shape[0],
-            image_width=frame_payload_list[0].image.shape[1],
-            frames_per_second=frames_per_second,
-            path_to_save_video_file=video_file_save_path,
+        packet = StreamingFramePacket(
+            frame_index=frame_index,
+            camera_id=str(frame_payload.camera_id),
+            timestamp_ns=int(frame_payload.timestamp_ns),
+            image=frame_payload.image,
         )
-        self._write_frame_list_to_video_file(frame_payload_list=frame_payload_list)
-        self._save_timestamps(timestamps_npy=self._timestamps_npy, video_file_save_path=video_file_save_path)
-        self._cv2_video_writer.release()
+        self._streaming_writer.submit(packet)
 
+    # -- legacy calibration-video path (unchanged) --------------------------
+    # save_image_list_to_disk operates on an already-complete, caller-owned
+    # image_list (e.g. a small set of calibration snapshots), not a live
+    # growing camera recording -- it was never implicated in the unbounded-
+    # memory bug and is left as-is.
     def save_image_list_to_disk(
             self,
             image_list: List[np.ndarray],
             path_to_save_video_file: Union[str, Path],
             frames_per_second: float,
     ):
-
         if len(image_list) == 0:
             logging.error(f"No frames to save for : {path_to_save_video_file}")
             return
 
-        self._cv2_video_writer = self._initialize_video_writer(
+        cv2_video_writer = self._initialize_video_writer(
             image_height=image_list[0].shape[0],
             image_width=image_list[0].shape[1],
             frames_per_second=frames_per_second,
             path_to_save_video_file=path_to_save_video_file,
         )
-        self._write_image_list_to_video_file(image_list)
+        try:
+            for image in image_list:
+                cv2_video_writer.write(image)
+        except Exception as e:
+            logger.error(f"Failed during save in video writer for video {str(path_to_save_video_file)}")
+            traceback.print_exc()
+            raise e
+        finally:
+            cv2_video_writer.release()
 
     def _initialize_video_writer(
             self,
@@ -93,9 +154,7 @@ class VideoRecorder:
             path_to_save_video_file: Union[str, Path],
             frames_per_second: Union[int, float] = None,
             fourcc: str = "mp4v",
-            # calibration_videos: bool = False,
     ) -> cv2.VideoWriter:
-
         video_writer_object = cv2.VideoWriter(
             str(path_to_save_video_file),
             cv2.VideoWriter_fourcc(*fourcc),
@@ -104,77 +163,7 @@ class VideoRecorder:
         )
 
         if not video_writer_object.isOpened():
-            logger.error(
-                f"cv2.VideoWriter failed to initialize for: {str(path_to_save_video_file)}"
-            )
+            logger.error(f"cv2.VideoWriter failed to initialize for: {str(path_to_save_video_file)}")
             raise Exception("cv2.VideoWriter is not open")
 
         return video_writer_object
-
-    def _write_frame_list_to_video_file(self, frame_payload_list: List[FramePayload]):
-
-        try:
-            for frame in tqdm(
-                    frame_payload_list,
-                    desc=f"Saving video: {self._path_to_save_video_file}",
-                    total=len(frame_payload_list),
-                    colour="cyan",
-                    unit="frames",
-                    dynamic_ncols=True,
-            ):
-                self._cv2_video_writer.write(frame.image)
-
-        except Exception as e:
-            logger.error(
-                f"Failed during save in video writer for video {str(self._path_to_save_video_file)}"
-            )
-            traceback.print_exc()
-            raise e
-        finally:
-            logger.info(f"Saved video to path: {self._path_to_save_video_file}")
-            self._cv2_video_writer.release()
-
-    def _write_image_list_to_video_file(self, image_list: List[np.ndarray]):
-        try:
-            for image in image_list:
-                self._cv2_video_writer.write(image)
-        except Exception as e:
-            logger.error(
-                f"Failed during save in video writer for video {str(self._path_to_save_video_file)}"
-            )
-            traceback.print_exc()
-            raise e
-        finally:
-            self._cv2_video_writer.release()
-
-    def _gather_timestamps(self, frame_payload_list: List[FramePayload]) -> np.ndarray:
-        timestamps_npy = np.empty(0)
-        try:
-            for frame_payload in frame_payload_list:
-                timestamps_npy = np.append(timestamps_npy, frame_payload.timestamp_ns)
-        except Exception as e:
-            logger.error("Error gathering timestamps")
-            logger.error(e)
-
-        return timestamps_npy
-
-    def _save_timestamps(self, timestamps_npy: np.ndarray, video_file_save_path: Union[str, Path]):
-        timestamp_folder_path = video_file_save_path.parent / "timestamps"
-        timestamp_folder_path.mkdir(parents=True, exist_ok=True)
-
-        base_timestamp_path_str = str(
-            timestamp_folder_path / video_file_save_path.stem
-        )
-
-        # save timestamps to npy (binary) file (via numpy.ndarray)
-        path_to_save_timestamps_npy = base_timestamp_path_str + "_binary.npy"
-        np.save(str(path_to_save_timestamps_npy), timestamps_npy)
-        logger.info(f"Saved timestamps to path: {str(path_to_save_timestamps_npy)}")
-
-        # save timestamps to human readable (csv/text) file (via pandas.DataFrame)
-        path_to_save_timestamps_csv = (
-                base_timestamp_path_str + "_timestamps_human_readable.csv"
-        )
-        timestamp_dataframe = pd.DataFrame(timestamps_npy)
-        timestamp_dataframe.to_csv(str(path_to_save_timestamps_csv))
-        logger.info(f"Saved timestamps to path: {str(path_to_save_timestamps_csv)}")

--- a/skellycam/tests/test_camera_group_streaming_submission.py
+++ b/skellycam/tests/test_camera_group_streaming_submission.py
@@ -1,0 +1,224 @@
+"""Regression tests for CamGroupThreadWorker's synchronized-frame-bundle
+submission path (_try_record_synchronized_frame_bundle / _abort_recording).
+
+These exercise the real production methods directly, with a fake camera
+group double and monkeypatched encoder -- no real camera, no QThread.start(),
+no Qt event loop required. See the checkpoint report for why the full
+QThread-based VideoSaveThreadWorker path is not exercised here.
+"""
+import numpy as np
+import pytest
+
+from skellycam.detection.models.frame_payload import FramePayload
+from skellycam.gui.qt.workers.camera_group_thread_worker import CamGroupThreadWorker
+from skellycam.opencv.video_recorder.video_recorder import VideoRecorder
+
+from skellycam.tests.test_streaming_video_writer import FakeEncoder
+
+
+class FakeCameraConfig:
+    def __init__(self, framerate=30):
+        self.framerate = framerate
+        self.use_this_camera = True
+
+
+class FakeCameraGroup:
+    """Minimal double: only what _initialize_video_recorder_dictionary()
+    and start_recording() actually touch."""
+
+    def __init__(self, camera_ids):
+        self.camera_config_dictionary = {cam_id: FakeCameraConfig() for cam_id in camera_ids}
+
+
+def make_frame_payload(camera_id: str, timestamp_ns: int) -> FramePayload:
+    return FramePayload(
+        success=True,
+        image=np.zeros((4, 4, 3), dtype=np.uint8),
+        timestamp_ns=timestamp_ns,
+        camera_id=camera_id,
+    )
+
+
+@pytest.fixture
+def worker(tmp_path, monkeypatch):
+    import skellycam.opencv.video_recorder.streaming_video_writer as sv_module
+    monkeypatch.setattr(sv_module, "Cv2FrameEncoder", lambda *a, **kw: FakeEncoder())
+
+    w = CamGroupThreadWorker(
+        camera_ids=None,  # avoids constructing a real CameraGroup / opening real cameras
+        get_new_synchronized_videos_folder_callable=lambda: tmp_path,
+    )
+    return w
+
+
+def start_recorder(worker, tmp_path, camera_id: str) -> VideoRecorder:
+    recorder = VideoRecorder()
+    recorder.start_streaming(
+        video_file_save_path=tmp_path / f"Camera_{camera_id}_synchronized.mp4",
+        expected_fps=30.0,
+    )
+    return recorder
+
+
+class TestSingleGlobalFrameIndex:
+    def test_one_bundle_gets_one_global_index_single_camera(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0"])
+        worker._video_recorder_dictionary = {"0": start_recorder(worker, tmp_path, "0")}
+
+        worker._try_record_synchronized_frame_bundle({"0": make_frame_payload("0", 0)})
+        assert worker._next_frame_index == 1
+        assert worker._video_recorder_dictionary["0"].number_of_frames == 1
+
+    def test_multiple_bundles_increment_monotonically_no_duplicates(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0"])
+        worker._video_recorder_dictionary = {"0": start_recorder(worker, tmp_path, "0")}
+
+        for i in range(10):
+            worker._try_record_synchronized_frame_bundle({"0": make_frame_payload("0", i * 33_000_000)})
+
+        assert worker._next_frame_index == 10
+        assert worker._video_recorder_dictionary["0"].number_of_frames == 10
+
+    def test_two_aligned_cameras_get_the_same_frame_index(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        worker._video_recorder_dictionary = {
+            "0": start_recorder(worker, tmp_path, "0"),
+            "1": start_recorder(worker, tmp_path, "1"),
+        }
+
+        worker._try_record_synchronized_frame_bundle({
+            "0": make_frame_payload("0", 1_000_000),
+            "1": make_frame_payload("1", 1_002_000),  # 2us apart -- well within threshold
+        })
+
+        assert worker._video_recorder_dictionary["0"].number_of_frames == 1
+        assert worker._video_recorder_dictionary["1"].number_of_frames == 1
+        assert worker._next_frame_index == 1
+
+
+class TestMissingCameraPreventsCommit:
+    def test_missing_camera_does_not_commit_bundle(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        worker._video_recorder_dictionary = {
+            "0": start_recorder(worker, tmp_path, "0"),
+            "1": start_recorder(worker, tmp_path, "1"),
+        }
+
+        # camera "1" has no frame this iteration -- must not partially commit
+        worker._try_record_synchronized_frame_bundle({"0": make_frame_payload("0", 0)})
+
+        assert worker._next_frame_index == 0
+        assert worker._video_recorder_dictionary["0"].number_of_frames == 0
+        assert worker._video_recorder_dictionary["1"].number_of_frames == 0
+
+    def test_none_frame_payload_treated_as_missing(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        worker._video_recorder_dictionary = {
+            "0": start_recorder(worker, tmp_path, "0"),
+            "1": start_recorder(worker, tmp_path, "1"),
+        }
+
+        worker._try_record_synchronized_frame_bundle({"0": make_frame_payload("0", 0), "1": None})
+
+        assert worker._next_frame_index == 0
+
+
+class TestStaleFrameGuard:
+    def test_frames_too_far_apart_in_time_are_not_paired(self, worker, tmp_path):
+        """The gap this checkpoint asked about: without this guard, a
+        backlogged frame from a slow camera could be silently paired with a
+        fresh frame from a fast one under the same frame_index."""
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        worker._video_recorder_dictionary = {
+            "0": start_recorder(worker, tmp_path, "0"),
+            "1": start_recorder(worker, tmp_path, "1"),
+        }
+        worker._max_frame_bundle_timestamp_delta_ns = 50_000_000  # 50ms
+
+        worker._try_record_synchronized_frame_bundle({
+            "0": make_frame_payload("0", 0),
+            "1": make_frame_payload("1", 200_000_000),  # 200ms apart -- well outside threshold
+        })
+
+        assert worker._next_frame_index == 0
+        assert worker._video_recorder_dictionary["0"].number_of_frames == 0
+        assert worker._video_recorder_dictionary["1"].number_of_frames == 0
+
+    def test_frames_within_threshold_are_paired(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        worker._video_recorder_dictionary = {
+            "0": start_recorder(worker, tmp_path, "0"),
+            "1": start_recorder(worker, tmp_path, "1"),
+        }
+        worker._max_frame_bundle_timestamp_delta_ns = 50_000_000
+
+        worker._try_record_synchronized_frame_bundle({
+            "0": make_frame_payload("0", 0),
+            "1": make_frame_payload("1", 10_000_000),  # 10ms apart -- within threshold
+        })
+
+        assert worker._next_frame_index == 1
+
+
+class TestAbortSemantics:
+    def test_partial_submission_then_failure_invalidates_all_outputs(self, worker, tmp_path, monkeypatch):
+        """Section 7's required test: camera 2 fails after camera 1 accepts
+        the frame. Exact zero-partial-submission is NOT claimed -- see the
+        docstring on _try_record_synchronized_frame_bundle -- but the whole
+        recording must still end up invalid, with no final files."""
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        recorder_0 = start_recorder(worker, tmp_path, "0")
+        recorder_1 = start_recorder(worker, tmp_path, "1")
+        worker._video_recorder_dictionary = {"0": recorder_0, "1": recorder_1}
+        worker._should_record_frames_bool = True
+
+        # Force camera "1"'s append to fail on this bundle, *after* camera
+        # "0" has already accepted its frame for the same frame_index --
+        # this is the non-atomic ordering the checkpoint flagged.
+        from skellycam.opencv.video_recorder.streaming_video_writer import WriterSaturatedError
+
+        original_append = VideoRecorder.append_frame_payload_to_list
+
+        def failing_append(self, frame_payload, frame_index):
+            if self is recorder_1:
+                raise WriterSaturatedError("simulated saturation on camera 1")
+            return original_append(self, frame_payload, frame_index)
+
+        monkeypatch.setattr(VideoRecorder, "append_frame_payload_to_list", failing_append)
+
+        worker._try_record_synchronized_frame_bundle({
+            "0": make_frame_payload("0", 0),
+            "1": make_frame_payload("1", 0),
+        })
+
+        # camera "0" DID accept frame_index 0 before camera "1" failed --
+        # confirming submission is not perfectly atomic (as documented) --
+        # but the abort must have fired and replaced the whole dictionary.
+        assert recorder_0.number_of_frames == 1  # accepted before the failure
+        assert worker._should_record_frames_bool is False  # recording stopped
+
+        # the dictionary was replaced with a fresh, empty one by _abort_recording
+        assert worker._video_recorder_dictionary["0"] is not recorder_0
+        assert worker._video_recorder_dictionary["1"] is not recorder_1
+        for fresh_recorder in worker._video_recorder_dictionary.values():
+            assert not fresh_recorder.is_streaming
+
+        # and the failed/aborted originals never produced a final file
+        assert not (tmp_path / "Camera_0_synchronized.mp4").exists()
+        assert not (tmp_path / "Camera_1_synchronized.mp4").exists()
+
+    def test_abort_recording_aborts_every_streaming_recorder(self, worker, tmp_path):
+        worker._camera_group = FakeCameraGroup(["0", "1"])
+        recorder_0 = start_recorder(worker, tmp_path, "0")
+        recorder_1 = start_recorder(worker, tmp_path, "1")
+        worker._video_recorder_dictionary = {"0": recorder_0, "1": recorder_1}
+        worker._should_record_frames_bool = True
+
+        worker._abort_recording(reason="test")
+
+        assert worker._should_record_frames_bool is False
+        # originals were aborted (stop_streaming/abort_streaming already
+        # called on them -- calling again would raise) -- verified via the
+        # fresh dictionary containing brand new, not-yet-started recorders
+        for fresh_recorder in worker._video_recorder_dictionary.values():
+            assert not fresh_recorder.is_streaming

--- a/skellycam/tests/test_streaming_memory_regression.py
+++ b/skellycam/tests/test_streaming_memory_regression.py
@@ -1,0 +1,507 @@
+"""Phase A synthetic memory regression tests for the streaming recorder.
+
+No real camera. Frames are generated one at a time and submitted directly to
+StreamingVideoWriter (and, for one integration test, through VideoRecorder),
+never pre-built into a full-recording list -- that would defeat the point of
+testing bounded memory.
+"""
+import gc
+import json
+import os
+import threading
+import time
+import weakref
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import psutil
+import pytest
+
+from skellycam.detection.models.frame_payload import FramePayload
+from skellycam.opencv.video_recorder.streaming_video_writer import (
+    Cv2FrameEncoder,
+    StreamingFramePacket,
+    StreamingVideoWriter,
+    WriterFailedError,
+    WriterSaturatedError,
+)
+from skellycam.opencv.video_recorder.video_recorder import VideoRecorder
+from skellycam.tests.test_streaming_video_writer import FakeEncoder
+
+
+# ---------------------------------------------------------------------------
+# Memory sampling helpers
+# ---------------------------------------------------------------------------
+
+def _rss_mib() -> float:
+    return psutil.Process(os.getpid()).memory_info().rss / (1024 ** 2)
+
+
+@dataclass
+class MemorySample:
+    frame_index: int
+    rss_mib: float
+    queue_depth: int
+    elapsed_seconds: float
+
+
+@dataclass
+class MemoryTrace:
+    rss_start_mib: float
+    rss_warm_mib: Optional[float] = None
+    samples: List[MemorySample] = field(default_factory=list)
+    rss_before_stop_mib: Optional[float] = None
+    rss_peak_during_stop_mib: Optional[float] = None
+    rss_after_stop_mib: Optional[float] = None
+    rss_after_gc_mib: Optional[float] = None
+    stop_duration_seconds: Optional[float] = None
+    peak_queue_depth: int = 0
+    result = None
+
+    @property
+    def rss_peak_submission_mib(self) -> float:
+        return max((s.rss_mib for s in self.samples), default=self.rss_start_mib)
+
+
+def _sample_rss_during(fn, interval_seconds: float = 0.005):
+    """Runs fn() while polling RSS on a background thread. Returns (result, peak_rss_mib)."""
+    peak = {"value": _rss_mib()}
+    stop_flag = threading.Event()
+
+    def sampler():
+        while not stop_flag.is_set():
+            peak["value"] = max(peak["value"], _rss_mib())
+            time.sleep(interval_seconds)
+
+    sampler_thread = threading.Thread(target=sampler, daemon=True)
+    sampler_thread.start()
+    result = fn()
+    stop_flag.set()
+    sampler_thread.join(timeout=2)
+    peak["value"] = max(peak["value"], _rss_mib())
+    return result, peak["value"]
+
+
+def run_synthetic_streaming_test(
+        tmp_path: Path,
+        width: int,
+        height: int,
+        frame_count: int,
+        queue_capacity: int = 60,
+        sample_every: int = 250,
+        encoder=None,
+        expected_fps: float = 30.0,
+        warmup_frames: int = 20,
+) -> MemoryTrace:
+    encoder = encoder or FakeEncoder()
+    writer = StreamingVideoWriter(
+        output_path=tmp_path / "synthetic.mp4",
+        expected_fps=expected_fps,
+        queue_capacity=queue_capacity,
+        encoder=encoder,
+    )
+
+    gc.collect()
+    trace = MemoryTrace(rss_start_mib=_rss_mib())
+    writer.start()
+
+    warmup_frames = min(warmup_frames, frame_count)
+    for i in range(warmup_frames):
+        frame = np.zeros((height, width, 3), dtype=np.uint8)
+        writer.submit(StreamingFramePacket(
+            frame_index=i, camera_id="0", timestamp_ns=i * 33_000_000, image=frame,
+        ))
+        del frame
+    time.sleep(0.05)
+    trace.rss_warm_mib = _rss_mib()
+
+    start_time = time.perf_counter()
+    for i in range(warmup_frames, frame_count):
+        frame = np.zeros((height, width, 3), dtype=np.uint8)  # one frame at a time -- never a full-recording list
+        writer.submit(StreamingFramePacket(
+            frame_index=i, camera_id="0", timestamp_ns=i * 33_000_000, image=frame,
+        ))
+        del frame  # explicit -- mirrors the production capture loop, which holds no frame reference after submit()
+
+        if i % sample_every == 0:
+            trace.samples.append(MemorySample(
+                frame_index=i, rss_mib=_rss_mib(), queue_depth=writer.queue_depth,
+                elapsed_seconds=time.perf_counter() - start_time,
+            ))
+
+    trace.peak_queue_depth = writer.peak_queue_depth
+    trace.rss_before_stop_mib = _rss_mib()
+
+    stop_start = time.perf_counter()
+    result, peak_during_stop = _sample_rss_during(lambda: writer.stop(timeout_seconds=30))
+    trace.stop_duration_seconds = time.perf_counter() - stop_start
+    trace.rss_peak_during_stop_mib = peak_during_stop
+    trace.rss_after_stop_mib = _rss_mib()
+    trace.peak_queue_depth = max(trace.peak_queue_depth, writer.peak_queue_depth)
+
+    gc.collect()
+    trace.rss_after_gc_mib = _rss_mib()
+    trace.result = result
+    return trace
+
+
+def assert_bounded_and_plateaued(
+        trace: MemoryTrace,
+        absolute_ceiling_mib: float,
+        max_growth_ratio_last_vs_first_third: float = 2.5,
+):
+    """Two independent checks, neither a brittle single exact-value assertion:
+
+    1. Absolute safety ceiling -- generous relative to the old architecture's
+       multi-GB growth, but still tight enough to catch a real regression.
+    2. Growth-slope/plateau check -- the *rate* of growth in the last third
+       of submission must not be meaningfully larger than the first third.
+       A bounded-queue architecture should plateau; the old unbounded list
+       grew ~linearly for the entire recording, so its last-third slope
+       would be comparable to (not smaller than) its first-third slope.
+    """
+    growth_mib = trace.rss_peak_submission_mib - trace.rss_start_mib
+    assert growth_mib < absolute_ceiling_mib, (
+        f"RSS grew {growth_mib:.1f} MiB during submission, exceeding the "
+        f"{absolute_ceiling_mib} MiB safety ceiling"
+    )
+
+    n = len(trace.samples)
+    assert n >= 6, "not enough samples to assess a growth trend"
+    third = max(n // 3, 1)
+    first_third = trace.samples[:third]
+    last_third = trace.samples[-third:]
+
+    first_delta = first_third[-1].rss_mib - trace.rss_start_mib
+    last_delta = last_third[-1].rss_mib - first_third[-1].rss_mib
+
+    # Guard against division-by-zero when growth is tiny/negative (noise) --
+    # in that case the plateau check trivially passes since there's nothing
+    # to be non-bounded about.
+    if first_delta > 1.0:
+        ratio = last_delta / first_delta if first_delta else 0
+        assert ratio < max_growth_ratio_last_vs_first_third, (
+            f"RSS growth did not plateau: first-third delta={first_delta:.1f} MiB, "
+            f"last-third delta={last_delta:.1f} MiB (ratio={ratio:.2f}, "
+            f"ceiling={max_growth_ratio_last_vs_first_third})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test A -- 960x540, 9000 frames (5-minute equivalent at 30fps)
+# ---------------------------------------------------------------------------
+
+class TestSyntheticMemory960x540:
+    def test_five_minute_equivalent_bounded_memory(self, tmp_path):
+        trace = run_synthetic_streaming_test(
+            tmp_path, width=960, height=540, frame_count=9000, queue_capacity=60, sample_every=500,
+        )
+
+        assert trace.result.success
+        assert trace.result.frames_submitted == 9000
+        assert trace.result.frames_written == 9000
+        assert trace.peak_queue_depth <= 60
+
+        # Absolute ceiling: 60-frame queue x ~1.48 MiB/frame (960x540x3) is
+        # ~90 MiB in flight at most, plus Python/GC/thread overhead. 400 MiB
+        # is generous headroom while still nowhere near the old architecture's
+        # multi-GB-for-the-whole-recording growth.
+        assert_bounded_and_plateaued(trace, absolute_ceiling_mib=400.0)
+
+        # Segment trend check requested explicitly: 0-1000, 4000-5000, 8000-9000
+        segments = {
+            "0-1000": [s for s in trace.samples if s.frame_index <= 1000],
+            "4000-5000": [s for s in trace.samples if 4000 <= s.frame_index <= 5000],
+            "8000-9000": [s for s in trace.samples if 8000 <= s.frame_index <= 9000],
+        }
+        segment_avgs = {
+            name: (sum(s.rss_mib for s in samples) / len(samples) if samples else None)
+            for name, samples in segments.items()
+        }
+        early, mid, late = segment_avgs["0-1000"], segment_avgs["4000-5000"], segment_avgs["8000-9000"]
+        if early is not None and late is not None:
+            # The late segment must not show continued *linear* growth
+            # comparable to the full early-to-mid delta happening *again*
+            # between mid and late.
+            early_to_mid = (mid - early) if mid is not None else 0
+            mid_to_late = (late - mid) if mid is not None else (late - early)
+            if early_to_mid > 1.0:
+                assert mid_to_late < early_to_mid * 2.5, (
+                    f"late-segment growth ({mid_to_late:.1f} MiB) still scales like early "
+                    f"growth ({early_to_mid:.1f} MiB) -- looks duration-linear, not plateaued"
+                )
+
+
+class TestSyntheticMemory1280x720:
+    def test_two_minute_equivalent_bounded_memory(self, tmp_path):
+        trace = run_synthetic_streaming_test(
+            tmp_path, width=1280, height=720, frame_count=3600, queue_capacity=60, sample_every=250,
+        )
+
+        assert trace.result.success
+        assert trace.result.frames_submitted == 3600
+        assert trace.result.frames_written == 3600
+        assert trace.peak_queue_depth <= 60
+
+        # This specific case is what previously carried an estimated
+        # 13-15 GiB Stop-time spike (see ARCHITECTURE_REPORT.md). The new
+        # implementation must not approach anything remotely similar --
+        # 400 MiB ceiling is ~35x smaller than even the old *steady-state*
+        # estimate (6.88 GiB) for this exact resolution/duration.
+        assert_bounded_and_plateaued(trace, absolute_ceiling_mib=400.0)
+
+        # Stop-time doubling check specific to this resolution/duration.
+        stop_delta = trace.rss_peak_during_stop_mib - trace.rss_before_stop_mib
+        assert stop_delta < 200.0, (
+            f"Stop-time RSS delta was {stop_delta:.1f} MiB -- the old architecture's "
+            f"deepcopy() would have doubled an already multi-GiB buffer at this point"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stop-time regression -- the most important Phase A check
+# ---------------------------------------------------------------------------
+
+class TestStopTimeRegression:
+    @pytest.mark.parametrize("frame_count", [300, 3000, 9000])
+    def test_stop_delta_does_not_scale_with_frame_count(self, tmp_path, frame_count):
+        trace = run_synthetic_streaming_test(
+            tmp_path, width=960, height=540, frame_count=frame_count, queue_capacity=60,
+            sample_every=max(frame_count // 10, 1),
+        )
+        stop_delta = trace.rss_peak_during_stop_mib - trace.rss_before_stop_mib
+        # Store on trace for the cross-parametrization comparison below via a module-level accumulator.
+        _STOP_DELTAS[frame_count] = stop_delta
+
+        assert trace.result.success
+        assert trace.result.frames_written == frame_count
+        # Bounded regardless of duration -- if Stop scaled with frame count
+        # (the old deepcopy behavior), 9000 frames would show a delta
+        # roughly 30x that of 300 frames at 960x540 (~3.9 GiB vs ~130 MiB).
+        assert stop_delta < 150.0, (
+            f"Stop RSS delta at {frame_count} frames was {stop_delta:.1f} MiB -- "
+            f"expected a small, roughly-constant delta regardless of duration"
+        )
+
+    def test_stop_delta_stays_approximately_constant_across_durations(self, tmp_path):
+        """Runs after the parametrized cases above have populated _STOP_DELTAS
+        (pytest executes tests in file order within a class by default)."""
+        if len(_STOP_DELTAS) < 3:
+            pytest.skip("requires all three parametrized Stop-delta cases to have run first")
+
+        deltas = list(_STOP_DELTAS.values())
+        smallest, largest = min(deltas), max(deltas)
+        # "Approximately constant" -- allow generous noise headroom (psutil
+        # RSS is not perfectly deterministic), but the 9000-frame case must
+        # not be wildly larger than the 300-frame case. The old architecture
+        # would show ~30x here; anything under 5x is a clear pass.
+        if smallest > 1.0:
+            assert (largest / smallest) < 5.0, (
+                f"Stop RSS deltas across durations were {_STOP_DELTAS} -- ratio "
+                f"{largest / smallest:.2f}x is too duration-dependent"
+            )
+
+
+_STOP_DELTAS = {}
+
+
+# ---------------------------------------------------------------------------
+# Retained-reference / garbage-collection test
+# ---------------------------------------------------------------------------
+
+class TestRetainedReference:
+    def test_frame_is_eligible_for_gc_after_write(self, tmp_path):
+        encoder = FakeEncoder()
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=encoder)
+        writer.start()
+
+        frame = np.zeros((16, 16, 3), dtype=np.uint8)
+        frame_ref = weakref.ref(frame)
+        writer.submit(StreamingFramePacket(frame_index=0, camera_id="0", timestamp_ns=0, image=frame))
+        del frame  # the only strong ref the test held
+
+        # give the drain thread time to consume and drop its own reference
+        deadline = time.time() + 2.0
+        while writer.frames_written < 1 and time.time() < deadline:
+            time.sleep(0.01)
+
+        gc.collect()
+        assert frame_ref() is None, "frame image was still referenced somewhere after being written"
+
+        writer.stop(timeout_seconds=5)
+
+    def test_video_recorder_does_not_retain_or_expose_frames(self, tmp_path, monkeypatch):
+        import skellycam.opencv.video_recorder.streaming_video_writer as sv_module
+        monkeypatch.setattr(sv_module, "Cv2FrameEncoder", lambda *a, **kw: FakeEncoder())
+
+        recorder = VideoRecorder()
+        recorder.start_streaming(video_file_save_path=tmp_path / "cam.mp4", expected_fps=30.0)
+
+        for i in range(10):
+            payload = FramePayload(
+                success=True, image=np.zeros((8, 8, 3), dtype=np.uint8), timestamp_ns=i, camera_id="0",
+            )
+            recorder.append_frame_payload_to_list(payload, frame_index=i)
+
+        # no attribute on VideoRecorder exposes a frame list/cache of any kind
+        assert not hasattr(recorder, "_frame_payload_list")
+        assert not hasattr(recorder, "frame_payload_list")
+        assert not any("frame" in attr.lower() and "list" in attr.lower() for attr in vars(recorder))
+
+        recorder.stop_streaming(timeout_seconds=5)
+
+    def test_queue_is_empty_after_drain(self, tmp_path):
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=FakeEncoder())
+        writer.start()
+        for i in range(20):
+            writer.submit(StreamingFramePacket(frame_index=i, camera_id="0", timestamp_ns=i, image=np.zeros((4, 4, 3), dtype=np.uint8)))
+        writer.stop(timeout_seconds=5)
+        assert writer.queue_depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Timestamp memory test
+# ---------------------------------------------------------------------------
+
+class TestTimestampMemory:
+    def test_timestamp_storage_is_scalar_only_and_matches_frame_count(self, tmp_path):
+        frame_count = 9000
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, queue_capacity=60, encoder=FakeEncoder(),
+        )
+        writer.start()
+        for i in range(frame_count):
+            writer.submit(StreamingFramePacket(
+                frame_index=i, camera_id="0", timestamp_ns=i * 33_000_000,
+                image=np.zeros((4, 4, 3), dtype=np.uint8),
+            ))
+        result = writer.stop(timeout_seconds=30)
+
+        assert result.success
+
+        # internal timestamp list is scalar tuples only, never image data
+        assert all(
+            isinstance(entry, tuple) and len(entry) == 2 and isinstance(entry[0], int)
+            for entry in writer._timestamps  # accessing internals deliberately, this is a white-box regression test
+        )
+        assert len(writer._timestamps) == frame_count
+
+        npy_files = list((tmp_path / "timestamps").glob("*_binary.npy"))
+        assert len(npy_files) == 1
+        saved = np.load(npy_files[0])
+        assert len(saved) == frame_count
+        assert list(saved) == sorted(saved)  # monotonic
+
+
+# ---------------------------------------------------------------------------
+# Real OpenCV encoder short test
+# ---------------------------------------------------------------------------
+
+class TestRealEncoderShortTest:
+    def test_real_short_recording_finalizes_and_is_readable(self, tmp_path):
+        cv2 = pytest.importorskip("cv2")
+
+        output_path = tmp_path / "Camera_000_synchronized.mp4"
+        partial_path = tmp_path / "Camera_000_synchronized.partial.mp4"
+        writer = StreamingVideoWriter(
+            output_path=output_path, expected_fps=15.0, queue_capacity=30,
+            encoder=Cv2FrameEncoder(),
+        )
+        writer.start()
+
+        frame_count = 150  # 10 seconds at 15fps
+        for i in range(frame_count):
+            frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+            writer.submit(StreamingFramePacket(
+                frame_index=i, camera_id="0", timestamp_ns=i * 66_666_667, image=frame,
+            ))
+            if i == 5:
+                # mid-recording: partial file must exist, final must not
+                assert partial_path.exists()
+                assert not output_path.exists()
+
+        assert not output_path.exists()  # still not finalized before Stop
+
+        result = writer.stop(timeout_seconds=15)
+
+        assert result.success
+        assert result.frames_written == frame_count
+        assert output_path.exists()
+        assert not partial_path.exists()  # atomic rename removed the partial name
+
+        cap = cv2.VideoCapture(str(output_path))
+        assert cap.isOpened()
+        reported_frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        cap.release()
+        # allow small container/codec rounding -- not an exact-equality brittle check
+        assert abs(reported_frame_count - frame_count) <= 2
+
+        timestamp_files = list((tmp_path / "timestamps").glob("*"))
+        assert len(timestamp_files) >= 2  # npy + csv
+
+
+# ---------------------------------------------------------------------------
+# Queue saturation
+# ---------------------------------------------------------------------------
+
+class TestQueueSaturationMemory:
+    def test_saturation_aborts_honestly_without_silent_drops(self, tmp_path):
+        output_path = tmp_path / "cam.mp4"
+        encoder = FakeEncoder(write_delay_seconds=5.0)  # writer effectively stalled
+        writer = StreamingVideoWriter(
+            output_path=output_path, expected_fps=30.0, queue_capacity=2,
+            submit_timeout_seconds=0.1, encoder=encoder,
+        )
+        writer.start()
+
+        submitted = 0
+        saturated = False
+        try:
+            for i in range(50):
+                writer.submit(StreamingFramePacket(frame_index=i, camera_id="0", timestamp_ns=i, image=np.zeros((4, 4, 3), dtype=np.uint8)))
+                submitted += 1
+        except WriterSaturatedError:
+            saturated = True
+
+        assert saturated
+        assert submitted < 50  # did not silently accept all 50 into an unbounded queue
+        assert not writer.is_healthy
+
+        result = writer.stop(timeout_seconds=1)
+        assert not result.success
+        assert not output_path.exists()
+        failure_files = list(tmp_path.glob("*.failure.json"))
+        assert len(failure_files) == 1
+        failure_data = json.loads(failure_files[0].read_text())
+        assert failure_data["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Writer failure
+# ---------------------------------------------------------------------------
+
+class TestWriterFailureMemory:
+    def test_failure_after_known_frame_count_is_honest(self, tmp_path):
+        output_path = tmp_path / "cam.mp4"
+        fail_after = 37
+        encoder = FakeEncoder(fail_after_n_writes=fail_after)
+        writer = StreamingVideoWriter(output_path=output_path, expected_fps=30.0, encoder=encoder)
+        writer.start()
+
+        for i in range(100):
+            try:
+                writer.submit(StreamingFramePacket(frame_index=i, camera_id="0", timestamp_ns=i, image=np.zeros((4, 4, 3), dtype=np.uint8)))
+            except WriterFailedError:
+                break
+
+        stop_start = time.perf_counter()
+        result = writer.stop(timeout_seconds=10)
+        stop_duration = time.perf_counter() - stop_start
+
+        assert not result.success
+        assert not output_path.exists()
+        assert result.partial_path is not None and result.partial_path.exists()
+        assert result.error is not None
+        assert stop_duration < 10.0  # Stop must not hang waiting on a dead writer thread

--- a/skellycam/tests/test_streaming_video_writer.py
+++ b/skellycam/tests/test_streaming_video_writer.py
@@ -1,0 +1,313 @@
+"""Regression tests for skellycam.opencv.video_recorder.streaming_video_writer.
+
+These are the direct-unit-level tests for the bounded-queue streaming
+recorder that replaced the unbounded frame_payload_list + Stop-time
+deepcopy() architecture (see ARCHITECTURE_REPORT.md). No real camera or
+cv2 encoder is required for most cases -- a FakeEncoder stands in so these
+run fast and deterministically.
+"""
+import queue
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from skellycam.opencv.video_recorder.streaming_video_writer import (
+    StreamingFramePacket,
+    StreamingVideoWriter,
+    WriterFailedError,
+    WriterSaturatedError,
+)
+
+
+class FakeEncoder:
+    """No-op encoder: records what it was asked to do without touching disk
+    or a real video codec, so memory/queue-behavior tests run fast."""
+
+    def __init__(self, fail_after_n_writes: int = None, open_delay_seconds: float = 0.0,
+                 write_delay_seconds: float = 0.0):
+        self.opened = False
+        self.open_args = None
+        self.write_count = 0
+        self.released = False
+        self._fail_after_n_writes = fail_after_n_writes
+        self._open_delay_seconds = open_delay_seconds
+        self._write_delay_seconds = write_delay_seconds
+
+    def open(self, path: Path, width: int, height: int, fps: float) -> bool:
+        if self._open_delay_seconds:
+            time.sleep(self._open_delay_seconds)
+        self.opened = True
+        self.open_args = (path, width, height, fps)
+        Path(path).touch()  # stand in for a real encoder creating the file on open()
+        return True
+
+    def write(self, image: np.ndarray) -> None:
+        if self._write_delay_seconds:
+            time.sleep(self._write_delay_seconds)
+        self.write_count += 1
+        if self._fail_after_n_writes is not None and self.write_count > self._fail_after_n_writes:
+            raise RuntimeError("FakeEncoder simulated write failure")
+
+    def release(self) -> None:
+        self.released = True
+
+
+def make_packet(frame_index: int, camera_id: str = "0", width: int = 4, height: int = 4) -> StreamingFramePacket:
+    return StreamingFramePacket(
+        frame_index=frame_index,
+        camera_id=camera_id,
+        timestamp_ns=frame_index * 33_000_000,
+        image=np.zeros((height, width, 3), dtype=np.uint8),
+    )
+
+
+class TestStreamingLifecycle:
+    def test_writer_opens_encoder_on_first_frame(self, tmp_path):
+        encoder = FakeEncoder()
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=encoder,
+        )
+        writer.start()
+        writer.submit(make_packet(0))
+        result = writer.stop(timeout_seconds=5)
+
+        assert encoder.opened
+        assert encoder.released
+        assert result.success
+        assert result.frames_written == 1
+
+    def test_frames_are_encoded_before_stop_returns(self, tmp_path):
+        encoder = FakeEncoder()
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=encoder)
+        writer.start()
+        for i in range(10):
+            writer.submit(make_packet(i))
+        result = writer.stop(timeout_seconds=5)
+
+        assert encoder.write_count == 10
+        assert result.frames_written == 10
+
+    def test_final_file_exists_only_after_success(self, tmp_path):
+        output_path = tmp_path / "cam.mp4"
+        encoder = FakeEncoder()
+        writer = StreamingVideoWriter(output_path=output_path, expected_fps=30.0, encoder=encoder)
+        writer.start()
+        writer.submit(make_packet(0))
+
+        assert not output_path.exists()  # not yet -- still recording
+        result = writer.stop(timeout_seconds=5)
+
+        assert result.output_path == output_path
+        assert result.partial_path is None
+
+    def test_stop_before_any_frame_submitted_fails_honestly(self, tmp_path):
+        encoder = FakeEncoder()
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=encoder)
+        writer.start()
+        result = writer.stop(timeout_seconds=5)
+
+        assert not result.success
+        assert result.frames_written == 0
+
+
+class TestBoundedMemory:
+    def test_queue_capacity_is_finite(self, tmp_path):
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, queue_capacity=5,
+            encoder=FakeEncoder(),
+        )
+        assert writer.queue_capacity == 5
+
+    def test_peak_queue_depth_never_exceeds_capacity(self, tmp_path):
+        # A slow encoder forces the queue to build up so we can observe peak depth.
+        encoder = FakeEncoder(write_delay_seconds=0.01)
+        capacity = 10
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, queue_capacity=capacity,
+            submit_timeout_seconds=2.0, encoder=encoder,
+        )
+        writer.start()
+        for i in range(30):
+            writer.submit(make_packet(i))
+        result = writer.stop(timeout_seconds=10)
+
+        assert result.success
+        assert result.peak_queue_depth <= capacity
+
+    def test_longer_simulated_duration_does_not_increase_queue_capacity(self, tmp_path):
+        """The core regression: capacity is a constant set at construction,
+        never a function of how many frames have been submitted -- unlike
+        the old unbounded frame_payload_list."""
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, queue_capacity=8,
+            encoder=FakeEncoder(),
+        )
+        writer.start()
+        for i in range(500):
+            writer.submit(make_packet(i))
+            assert writer.queue_capacity == 8  # constant, regardless of frames submitted so far
+        writer.stop(timeout_seconds=5)
+
+
+class TestDeepcopyRegression:
+    def test_stop_path_never_calls_deepcopy(self, tmp_path, monkeypatch):
+        import copy
+
+        calls = []
+        original_deepcopy = copy.deepcopy
+
+        def spy_deepcopy(*args, **kwargs):
+            calls.append(args)
+            return original_deepcopy(*args, **kwargs)
+
+        monkeypatch.setattr(copy, "deepcopy", spy_deepcopy)
+
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=FakeEncoder())
+        writer.start()
+        for i in range(5):
+            writer.submit(make_packet(i))
+        writer.stop(timeout_seconds=5)
+
+        assert calls == [], "StreamingVideoWriter.stop() must never deepcopy anything"
+
+    def test_camera_group_thread_worker_source_contains_no_deepcopy(self):
+        """Prevent the removed recorder-deepcopy call from returning.
+
+        Explanatory comments and docstrings may still mention deepcopy.
+        """
+        import re
+        from pathlib import Path
+
+        import skellycam.gui.qt.workers.camera_group_thread_worker as worker_module
+
+        source_path = Path(worker_module.__file__)
+        source = source_path.read_text()
+
+        assert re.search(
+            r"\bdeepcopy\s*\(\s*video_recorder\s*\)",
+            source,
+        ) is None
+
+        assert re.search(
+            r"^\s*from\s+copy\s+import\s+deepcopy\s*$",
+            source,
+            flags=re.MULTILINE,
+        ) is None
+
+
+class TestQueueSaturation:
+    def test_persistent_saturation_raises_and_fails_honestly(self, tmp_path):
+        # Encoder that never drains (long delay per write) + tiny queue + short submit timeout
+        encoder = FakeEncoder(write_delay_seconds=5.0)
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, queue_capacity=1,
+            submit_timeout_seconds=0.1, encoder=encoder,
+        )
+        writer.start()
+        writer.submit(make_packet(0))  # fills the single slot; drain loop is now stuck writing it
+
+        with pytest.raises(WriterSaturatedError):
+            writer.submit(make_packet(1))
+            writer.submit(make_packet(2))  # one of these should overflow the capacity-1 queue
+
+        assert not writer.is_healthy
+
+    def test_submit_after_failure_raises_writer_failed(self, tmp_path):
+        encoder = FakeEncoder(write_delay_seconds=5.0)
+        writer = StreamingVideoWriter(
+            output_path=tmp_path / "cam.mp4", expected_fps=30.0, queue_capacity=1,
+            submit_timeout_seconds=0.1, encoder=encoder,
+        )
+        writer.start()
+        writer.submit(make_packet(0))
+        with pytest.raises(WriterSaturatedError):
+            for i in range(1, 5):
+                writer.submit(make_packet(i))
+
+        with pytest.raises(WriterFailedError):
+            writer.submit(make_packet(99))
+
+    def test_saturation_preserves_partial_file_not_reported_complete(self, tmp_path):
+        output_path = tmp_path / "cam.mp4"
+        encoder = FakeEncoder(write_delay_seconds=5.0)
+        writer = StreamingVideoWriter(
+            output_path=output_path, expected_fps=30.0, queue_capacity=1,
+            submit_timeout_seconds=0.1, encoder=encoder,
+        )
+        writer.start()
+        writer.submit(make_packet(0))
+        try:
+            for i in range(1, 5):
+                writer.submit(make_packet(i))
+        except WriterSaturatedError:
+            pass
+
+        result = writer.stop(timeout_seconds=1)  # writer thread is stuck in a 5s sleep -- expect a timeout-based failure too
+
+        assert not result.success
+        assert not output_path.exists()
+
+
+class TestWriterFailure:
+    def test_encoder_write_exception_fails_the_recording(self, tmp_path):
+        output_path = tmp_path / "cam.mp4"
+        encoder = FakeEncoder(fail_after_n_writes=3)
+        writer = StreamingVideoWriter(output_path=output_path, expected_fps=30.0, encoder=encoder)
+        writer.start()
+        for i in range(10):
+            try:
+                writer.submit(make_packet(i))
+            except WriterFailedError:
+                break
+        result = writer.stop(timeout_seconds=5)
+
+        assert not result.success
+        assert not output_path.exists()
+        assert result.partial_path is not None
+
+    def test_encoder_open_failure_is_reported(self, tmp_path):
+        class FailToOpenEncoder(FakeEncoder):
+            def open(self, path, width, height, fps) -> bool:
+                return False
+
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=FailToOpenEncoder())
+        writer.start()
+        writer.submit(make_packet(0))
+        result = writer.stop(timeout_seconds=5)
+
+        assert not result.success
+        assert result.error is not None
+
+
+class TestTimestampBehavior:
+    def test_timestamps_written_incrementally_not_all_at_once(self, tmp_path):
+        """The historical bug used np.append() in a loop (O(n^2)). This test
+        proves the internal timestamp list grows one scalar tuple at a time
+        during the drain loop, and is converted to a numpy array exactly
+        once at finalize -- not per-frame."""
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=FakeEncoder())
+        writer.start()
+        for i in range(50):
+            writer.submit(make_packet(i))
+        writer.stop(timeout_seconds=5)
+
+        # after stop(), the npy/csv files should exist with exactly 50 rows
+        timestamp_folder = (tmp_path / "timestamps")
+        npy_files = list(timestamp_folder.glob("*_binary.npy"))
+        assert len(npy_files) == 1
+        saved = np.load(npy_files[0])
+        assert len(saved) == 50
+        assert list(saved) == sorted(saved)  # monotonic, matches submission order
+
+    def test_frame_index_sequence_is_monotonic(self, tmp_path):
+        writer = StreamingVideoWriter(output_path=tmp_path / "cam.mp4", expected_fps=30.0, encoder=FakeEncoder())
+        writer.start()
+        indices = list(range(20))
+        for i in indices:
+            writer.submit(make_packet(i))
+        writer.stop(timeout_seconds=5)
+
+        assert writer.frames_written == len(indices)

--- a/skellycam/tests/test_video_recorder_streaming.py
+++ b/skellycam/tests/test_video_recorder_streaming.py
@@ -1,0 +1,109 @@
+"""Regression tests for skellycam.opencv.video_recorder.video_recorder.VideoRecorder
+after its rewrite onto StreamingVideoWriter.
+"""
+import numpy as np
+import pytest
+
+from skellycam.detection.models.frame_payload import FramePayload
+from skellycam.opencv.video_recorder.video_recorder import VideoRecorder
+from skellycam.opencv.video_recorder.streaming_video_writer import (
+    Cv2FrameEncoder,
+    WriterFailedError,
+    WriterSaturatedError,
+)
+
+from skellycam.tests.test_streaming_video_writer import FakeEncoder
+
+
+def make_frame_payload(camera_id: str = "0", timestamp_ns: int = 0) -> FramePayload:
+    return FramePayload(
+        success=True,
+        image=np.zeros((4, 4, 3), dtype=np.uint8),
+        timestamp_ns=timestamp_ns,
+        camera_id=camera_id,
+    )
+
+
+class TestUnboundedListRemoved:
+    def test_no_frame_payload_list_attribute_exists(self):
+        """Regression guard for the actual root cause: VideoRecorder must
+        never again accumulate frames in an unbounded list."""
+        recorder = VideoRecorder()
+        assert not hasattr(recorder, "_frame_payload_list")
+        assert not hasattr(recorder, "frame_payload_list")
+
+    def test_no_cv2_video_writer_instance_state(self):
+        recorder = VideoRecorder()
+        assert not hasattr(recorder, "_cv2_video_writer")
+
+    def test_number_of_frames_is_zero_before_streaming(self):
+        recorder = VideoRecorder()
+        assert recorder.number_of_frames == 0
+
+
+class TestStreamingLifecycleViaVideoRecorder:
+    def test_start_submit_stop_cycle(self, tmp_path, monkeypatch):
+        recorder = VideoRecorder()
+        # substitute the internal encoder with a fake one via the module-level
+        # default -- simplest is to monkeypatch Cv2FrameEncoder used inside
+        # StreamingVideoWriter's default construction path.
+        import skellycam.opencv.video_recorder.streaming_video_writer as sv_module
+        monkeypatch.setattr(sv_module, "Cv2FrameEncoder", lambda *a, **kw: FakeEncoder())
+
+        recorder.start_streaming(video_file_save_path=tmp_path / "Camera_000_synchronized.mp4", expected_fps=30.0)
+        for i in range(5):
+            recorder.append_frame_payload_to_list(make_frame_payload(timestamp_ns=i * 1_000), frame_index=i)
+
+        assert recorder.number_of_frames == 5
+
+        result = recorder.stop_streaming(timeout_seconds=5)
+        assert result.success
+        assert result.frames_written == 5
+
+    def test_append_requires_frame_index(self, tmp_path, monkeypatch):
+        import skellycam.opencv.video_recorder.streaming_video_writer as sv_module
+        monkeypatch.setattr(sv_module, "Cv2FrameEncoder", lambda *a, **kw: FakeEncoder())
+
+        recorder = VideoRecorder()
+        recorder.start_streaming(video_file_save_path=tmp_path / "cam.mp4", expected_fps=30.0)
+        with pytest.raises(TypeError):
+            recorder.append_frame_payload_to_list(make_frame_payload())  # missing frame_index -- signature is intentionally required, see checkpoint report
+
+    def test_append_before_start_raises(self):
+        recorder = VideoRecorder()
+        with pytest.raises(RuntimeError):
+            recorder.append_frame_payload_to_list(make_frame_payload(), frame_index=0)
+
+    def test_abort_streaming_marks_unhealthy_and_preserves_partial(self, tmp_path, monkeypatch):
+        import skellycam.opencv.video_recorder.streaming_video_writer as sv_module
+        monkeypatch.setattr(sv_module, "Cv2FrameEncoder", lambda *a, **kw: FakeEncoder())
+
+        output_path = tmp_path / "cam.mp4"
+        recorder = VideoRecorder()
+        recorder.start_streaming(video_file_save_path=output_path, expected_fps=30.0)
+        recorder.append_frame_payload_to_list(make_frame_payload(), frame_index=0)
+
+        result = recorder.abort_streaming(reason="test abort")
+        assert not result.success
+        assert not output_path.exists()
+
+
+class TestLegacyCalibrationPathUnchanged:
+    """save_image_list_to_disk operates on an already-complete, caller-owned
+    list -- it was never implicated in the unbounded-memory bug and must
+    keep working exactly as before."""
+
+    def test_save_image_list_to_disk_still_works(self, tmp_path):
+        recorder = VideoRecorder()
+        images = [np.zeros((4, 4, 3), dtype=np.uint8) for _ in range(3)]
+        output_path = tmp_path / "calibration.mp4"
+        recorder.save_image_list_to_disk(
+            image_list=images, path_to_save_video_file=output_path, frames_per_second=30.0,
+        )
+        assert output_path.exists()
+
+    def test_save_image_list_to_disk_handles_empty_list(self, tmp_path):
+        recorder = VideoRecorder()
+        recorder.save_image_list_to_disk(
+            image_list=[], path_to_save_video_file=tmp_path / "empty.mp4", frames_per_second=30.0,
+        )  # should log and return, not raise

--- a/tools/calculate_recording_memory.py
+++ b/tools/calculate_recording_memory.py
@@ -1,0 +1,96 @@
+"""Estimate raw in-RAM memory for an unbounded per-frame recording buffer.
+
+Does not allocate anything -- pure arithmetic, for sizing decisions and for
+reasoning about the memory-repair sprint's regression tests.
+"""
+import argparse
+from dataclasses import dataclass
+
+
+@dataclass
+class RecordingMemoryEstimate:
+    frame_bytes: int
+    frames_per_camera: int
+    total_frames: int
+    raw_bytes: int
+    raw_with_copy_multiplier_bytes: int
+
+    @property
+    def raw_gib(self) -> float:
+        return self.raw_bytes / (1024 ** 3)
+
+    @property
+    def raw_with_copy_multiplier_gib(self) -> float:
+        return self.raw_with_copy_multiplier_bytes / (1024 ** 3)
+
+
+def estimate_recording_memory(
+        width: int,
+        height: int,
+        channels: int,
+        fps: float,
+        duration_seconds: float,
+        camera_count: int,
+        copy_multiplier: float,
+) -> RecordingMemoryEstimate:
+    """copy_multiplier accounts for transient duplicates (e.g. deepcopy() at
+    Stop) that coexist with the original buffer for a period of time. Use
+    1.0 for steady-state accumulation only, 2.0 to model a single full
+    deepcopy of the buffer existing alongside the original."""
+    frame_bytes = width * height * channels
+    frames_per_camera = round(fps * duration_seconds)
+    total_frames = frames_per_camera * camera_count
+    raw_bytes = frame_bytes * total_frames
+    raw_with_copy_multiplier_bytes = round(raw_bytes * copy_multiplier)
+
+    return RecordingMemoryEstimate(
+        frame_bytes=frame_bytes,
+        frames_per_camera=frames_per_camera,
+        total_frames=total_frames,
+        raw_bytes=raw_bytes,
+        raw_with_copy_multiplier_bytes=raw_with_copy_multiplier_bytes,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--width", type=int, default=1280)
+    parser.add_argument("--height", type=int, default=720)
+    parser.add_argument("--channels", type=int, default=3)
+    parser.add_argument("--fps", type=float, default=30.0)
+    parser.add_argument("--duration", type=float, default=89.0,
+                         help="recording duration in seconds")
+    parser.add_argument("--cameras", type=int, default=1)
+    parser.add_argument("--copy-multiplier", type=float, default=1.0,
+                         help="1.0 = steady-state buffer only; "
+                              "2.0 = models a full deepcopy() coexisting "
+                              "with the original at Stop")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    estimate = estimate_recording_memory(
+        width=args.width,
+        height=args.height,
+        channels=args.channels,
+        fps=args.fps,
+        duration_seconds=args.duration,
+        camera_count=args.cameras,
+        copy_multiplier=args.copy_multiplier,
+    )
+
+    print(f"Frame size: {estimate.frame_bytes:,} bytes "
+          f"({estimate.frame_bytes / (1024 ** 2):.2f} MiB)")
+    print(f"Frames per camera: {estimate.frames_per_camera:,}")
+    print(f"Total frames ({args.cameras} camera(s)): {estimate.total_frames:,}")
+    print(f"Estimated raw buffer: {estimate.raw_bytes:,} bytes "
+          f"({estimate.raw_gib:.2f} GiB)")
+    if args.copy_multiplier != 1.0:
+        print(f"With copy_multiplier={args.copy_multiplier}: "
+              f"{estimate.raw_with_copy_multiplier_bytes:,} bytes "
+              f"({estimate.raw_with_copy_multiplier_gib:.2f} GiB)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR replaces SkellyCam's unbounded in-memory recording buffer with a
bounded, asynchronous stream-to-disk writer.

Frames are encoded continuously while recording rather than accumulated
until Stop. The Stop-time `VideoRecorder` `deepcopy()` is removed through
ownership transfer, and final outputs are published atomically only after
successful writer shutdown.

Related: freemocap/freemocap#650

## Problem

`VideoRecorder` stores every captured frame (full-resolution image
included) in an unbounded Python list for the entire recording. At Stop,
each active recorder is `deepcopy()`-ed -- duplicating all buffered frame
data -- before being handed to the background save worker. Memory use
scales with recording duration and spikes at Stop. On a 16GB Apple Silicon
Mac, a single-camera ~89-second recording triggered a macOS jetsam cascade
and a full system freeze.

## Root cause

- `video_recorder.py`: `append_frame_payload_to_list()` appends to an
  unbounded `_frame_payload_list`.
- `camera_group_thread_worker.py`: `deepcopy(video_recorder)` at Stop.
- The encoder itself (`_write_frame_list_to_video_file()`) already writes
  frame-by-frame in a loop -- encoding was never the bottleneck. The
  problem is that nothing is written until Stop, and the writer isn't
  opened until then either.

## Implementation

- New `StreamingVideoWriter` (`streaming_video_writer.py`): bounded queue,
  default capacity 60 frames per camera (~2s at 30fps, documented and
  configurable)
- Background writer thread drains the queue continuously; encoder is
  opened at recording Start, not Stop
- Frames are written and released immediately -- no per-recording
  accumulation, no per-frame retention beyond one in-flight frame in the
  drain thread
- Incremental scalar timestamp collection (`(frame_index, timestamp_ns)`
  tuples), converted to the existing npy/csv output format once at
  finalize -- replaces a previous `np.append()`-in-a-loop pattern
- Partial output files (`*.partial.mp4`) during recording; atomic rename to
  the final filename only on verified success
- Explicit queue-saturation failure (`WriterSaturatedError`) if the queue
  stays full past a short timeout -- no silent frame dropping
- Explicit encoder-failure propagation (`WriterFailedError`) -- a failed
  writer cannot silently continue
- No final output is ever published after any failure; failure metadata
  (`*.failure.json`) is written alongside the preserved partial file
- Deterministic per-camera submission order (iterates the worker's own
  dict insertion order, not an unordered `set`) -- makes failure behavior
  reproducible rather than incidental
- `camera_group_thread_worker.py`'s Stop path now detaches the active
  recorder dictionary and immediately constructs a fresh, empty one for the
  next recording, handing the *originals* (not copies) to the background
  finalize worker -- this is what removes the `deepcopy()`
- Provisional per-poll-iteration timestamp-delta guard for multi-camera
  frame bundles (see Known limitations -- this is new behavior, not a
  proven-equivalent replacement for the previous algorithm)

## Failure behavior

Any writer failure (queue saturation or encoder error) aborts the entire
synchronized recording -- all cameras' writers are aborted together, so a
partially-successful recording is never reported as complete. Partial files
and failure metadata remain on disk for diagnosis. Submission across
cameras for one synchronized frame bundle is not perfectly atomic (one
camera's writer can accept a frame microseconds before another's fails on
the same bundle) -- this is documented and tested explicitly rather than
assumed away; the recording is still invalidated as a whole regardless.

## Memory results

Synthetic, no real camera:

| Case | Frames | RSS growth | Stop delta |
|---|---|---|---|
| 960x540 (5-min equivalent) | 9,000 | ~1.7 MiB | ~1.8 MiB |
| 1280x720 (2-min equivalent) | 3,600 | ~10.9 MiB | ~0.1 MiB |

Both cases plateau rather than growing linearly with frame count, and the
Stop delta does not scale with recording duration (measured flat across
300/3,000/9,000-frame runs). RSS values are platform-specific and should
not be read as universal benchmarks.

## Test results

- New/focused test suite: 47 passed, 0 failed (writer lifecycle, bounded
  memory, deepcopy regression, queue saturation, writer failure, timestamp
  behavior, multi-camera submission logic, synthetic memory regression)
- Existing SkellyCam suite: 48 passed, 2 pre-existing collection errors
  (helper functions named with a `test_` prefix that require arguments no
  pytest fixture provides -- present before this change, not introduced by
  it), 0 new regressions

## Live validation

Real single-camera hardware test (isolated development build, not the
installed production app): 640x480, single built-in camera, ~33s/975
frames recorded. Baseline RSS 769.3 MiB, immediately post-Stop 788.5 MiB
(+19.2 MiB), flat for a full 2-minute post-Stop observation window. No
crash, freeze, or jetsam event. Output MP4 finalized atomically and was
verified readable via OpenCV. Zero unexpected processing artifacts.

## Backward compatibility

Public-facing recorder lifecycle (`start_recording`/`stop_recording`,
`videos_saved_to_this_folder_signal`) is unchanged. `VideoRecorder.
append_frame_payload_to_list()` keeps its name but now requires an explicit
`frame_index` argument (previously took none); the one other, non-live
caller of the old signature (`skellycam/experiments/multi_camera_recorder/`,
an unmaintained example script not imported by the main package) was
already independently incompatible with the new architecture in multiple
other ways (direct access to the now-removed `_frame_payload_list`
attribute, a removed `.timestamps` property) and was not updated as part
of this PR -- flagged for maintainers to decide whether to update or remove
it separately.

## Known limitations

- Single-camera recording is validated through synthetic and live tests.
- Multi-camera synchronization has not yet been validated with physical
  cameras.
- The incremental multi-camera bundle logic is not proven equivalent to
  the previous post-hoc nearest-timestamp matching algorithm.
- The streaming writer currently opens with the configured FPS. When the
  camera's achieved FPS differs from that value, playback speed can be
  incorrect. Observed directly in live testing (config 15fps, measured
  ~29fps achieved).
- This PR does not change FreeMoCap motion-capture processing, MediaPipe
  processing, Blender export, or notebook generation.
- Diagnostic plots (Windows-only code path, `create_diagnostic_plots`) are
  no longer generated, since they required the old full in-RAM frame
  buffer. Not tested on Windows.
- No production PyApp installation is included in this PR -- validated
  against an isolated development checkout only.

## Review focus

1. Whether the timestamp-delta synchronization guard is an acceptable
   provisional approach for multi-camera use, or whether it should block
   merge until validated on real multi-camera hardware.
2. Whether the non-atomic per-camera submission ordering (documented above)
   is an acceptable tradeoff.
3. Whether the FPS-metadata limitation should block merge or ship as a
   documented follow-up.

## Reviewer checklist

- [ ] Queue remains bounded (default 60 frames/camera, configurable)
- [ ] Frames are encoded during capture, not batched at Stop
- [ ] `VideoRecorder` stores no full recording frame list
- [ ] Stop path contains no recorder `deepcopy()`
- [ ] Failure never publishes a final MP4
- [ ] Partial outputs remain diagnosable
- [ ] Timestamp count matches frame count
- [ ] Queue saturation is explicit
- [ ] Encoder failure is explicit
- [ ] Existing single-camera API remains usable
- [ ] Multi-camera synchronization concerns reviewed
- [ ] FPS metadata limitation acknowledged
- [ ] macOS and non-macOS behavior considered

Opened as a **draft PR**: multi-camera physical validation is incomplete,
FPS metadata handling remains unresolved, and maintainer architectural
input (particularly on the synchronization approach) would be valuable
before this is ready for final review.
