### PR TITLE
add checks for numpy objects when serializing timestamp stats to json

### DIFF
--- a/skellycam/core/timestamps/recording_timestamp_stats.py
+++ b/skellycam/core/timestamps/recording_timestamp_stats.py
@@ -132,6 +132,19 @@ class RecordingTimestampsStats:
                         value = getattr(obj, field.name)
                         result[field.name.replace("_value", "")] = _to_serializable(value)
                 return result
+            elif isinstance(obj, np.ndarray) and obj.dtype.names:
+                # np.recarray (e.g. the per-metric stats produced by calculate_statistics)
+                # is not a dataclass, so it fell through to json.dumps' `default=`, whose
+                # `o.__dict__` is always {} for ndarrays - the fields live in the C buffer,
+                # not the instance dict. Pull them out by name instead.
+                return {
+                    name.replace("_value", ""): _to_serializable(obj[name])
+                    for name in obj.dtype.names
+                }
+            elif isinstance(obj, np.ndarray):
+                return obj.tolist()
+            elif isinstance(obj, np.generic):
+                return obj.item()
             elif isinstance(obj, list):
                 return [_to_serializable(item) for item in obj]
             elif isinstance(obj, dict):


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The timestamp stats `.txt` file works, but the `.json` implementation is broken because of how it is serialized. This makes sure numpy objects are correctly serialized, thus saving the data to disk in a machine readable format.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

Here is a before `.json`: 
```
{
    "recording_info": {
        "recording_name": "2026-08-07_00-00-36_GMT-6",
        "recording_directory": "/Users/philipqueen/freemocap_data/recordings",
        "recording_uuid": "71f86a87-e05c-4559-b598-f3206c8c50d7",
        "mic_device_index": -1,
        "recording_start_timestamp": {
            "unix_timestamp_utc": 1786082436.639207,
            "unix_timestamp_local": 1786082436.639207,
            "unix_timestamp_utc_isoformat": "2026-08-07T06:00:36.639207+00:00",
            "unix_timestamp_local_isoformat": "2026-08-07T00:00:36.639207-06:00",
            "local_time_zone": "America/Denver",
            "human_friendly_utc": "2026-08-07 06:00:36.639207",
            "human_friendly_local": "2026-08-07 00:00:36.639207",
            "day_of_week": "Friday",
            "calendar_week": 32,
            "day_of_year": 219,
            "is_leap_year": false,
            "perf_counter_ns": 13387370298875
        }
    },
    "number_of_cameras": 1,
    "number_of_frames": 76,
    "total_duration_sec": 5.049000104,
    "framerate_stats": {},
    "frame_duration_stats": {},
    "inter_camera_grab_range_ms": {},
    "idle_before_frame_grab_ms": {},
    "during_frame_grab_ms": {},
    "idle_before_retrieve_ms": {},
    "during_frame_retrieve_ms": {},
    "idle_before_copy_to_camera_shm_ms": {},
    "during_copy_to_camera_shm_ms": {},
    "idle_before_frame_record_ms": {},
    "during_frame_record_ms": {},
    "total_frame_processing_time_ms": {},
    "total_camera_idle_time_ms": {}
}
```
And an after:
```
{
    "recording_info": {
        "recording_name": "2026-08-07_22-24-13_GMT-6",
        "recording_directory": "/Users/philipqueen/freemocap_data/recordings",
        "recording_uuid": "5a7b8e2e-9f09-4ff7-b354-4b653130a087",
        "mic_device_index": -1,
        "recording_start_timestamp": {
            "unix_timestamp_utc": 1786163053.9222,
            "unix_timestamp_local": 1786163053.9222,
            "unix_timestamp_utc_isoformat": "2026-08-08T04:24:13.922200+00:00",
            "unix_timestamp_local_isoformat": "2026-08-07T22:24:13.922200-06:00",
            "local_time_zone": "America/Denver",
            "human_friendly_utc": "2026-08-08 04:24:13.922200",
            "human_friendly_local": "2026-08-07 22:24:13.922200",
            "day_of_week": "Friday",
            "calendar_week": 32,
            "day_of_year": 219,
            "is_leap_year": false,
            "perf_counter_ns": 56429554120750
        }
    },
    "number_of_cameras": 1,
    "number_of_frames": 45,
    "total_duration_sec": 2.967663166,
    "framerate_stats": {
        "mean": 15.03607404500285,
        "median": 15.088404447879793,
        "standard_deviation": 0.7698783266990727,
        "coefficient_of_variation": 0.05120208402770783,
        "min": 12.162296802074868,
        "max": 17.201162991271236,
        "range": 5.0388661891963675
    },
    "frame_duration_stats": {
        "mean": 66.70256297727273,
        "median": 66.276083,
        "standard_deviation": 3.854985293737569,
        "coefficient_of_variation": 0.057793660718120546,
        "min": 58.135604,
        "max": 82.221312,
        "range": 24.085707999999997
    },
    "inter_camera_grab_range_ms": {
        "mean": 0.0,
        "median": 0.0,
        "standard_deviation": 0.0,
        "coefficient_of_variation": NaN,
        "min": 0.0,
        "max": 0.0,
        "range": 0.0
    },
    "idle_before_frame_grab_ms": {
        "mean": 0.47761024444444444,
        "median": 0.214709,
        "standard_deviation": 1.5390305220249556,
        "coefficient_of_variation": 3.2223565970934183,
        "min": 0.1345,
        "max": 10.634916,
        "range": 10.500416000000001
    },
    "during_frame_grab_ms": {
        "mean": 63.55357402222223,
        "median": 63.553833,
        "standard_deviation": 6.053871897722929,
        "coefficient_of_variation": 0.09525619905508577,
        "min": 45.972792,
        "max": 95.051584,
        "range": 49.07879200000001
    },
    "idle_before_retrieve_ms": {
        "mean": 0.07927877777777778,
        "median": 0.055875,
        "standard_deviation": 0.07134984615973101,
        "coefficient_of_variation": 0.8999867071579744,
        "min": 0.043166,
        "max": 0.377542,
        "range": 0.334376
    },
    "during_frame_retrieve_ms": {
        "mean": 0.12011577777777777,
        "median": 0.109542,
        "standard_deviation": 0.02714676307357545,
        "coefficient_of_variation": 0.22600497266727756,
        "min": 0.096958,
        "max": 0.214458,
        "range": 0.11750000000000001
    },
    "idle_before_copy_to_camera_shm_ms": {
        "mean": 0.39044717777777777,
        "median": 0.352333,
        "standard_deviation": 0.10498523328762613,
        "coefficient_of_variation": 0.26888460017856314,
        "min": 0.284625,
        "max": 0.850833,
        "range": 0.5662079999999999
    },
    "during_copy_to_camera_shm_ms": {
        "mean": 0.8208665999999999,
        "median": 0.806666,
        "standard_deviation": 0.20394124659773952,
        "coefficient_of_variation": 0.24844627202244499,
        "min": 0.4775,
        "max": 1.51225,
        "range": 1.03475
    },
    "idle_before_frame_record_ms": {
        "mean": 0.06875653333333333,
        "median": 0.057666,
        "standard_deviation": 0.027307657798256273,
        "coefficient_of_variation": 0.39716455257957944,
        "min": 0.047125,
        "max": 0.17225,
        "range": 0.125125
    },
    "during_frame_record_ms": {
        "mean": 0.9862990222222223,
        "median": 0.896708,
        "standard_deviation": 0.437747997341976,
        "coefficient_of_variation": 0.44382888706073087,
        "min": 0.679792,
        "max": 3.647875,
        "range": 2.968083
    },
    "total_frame_processing_time_ms": {
        "mean": 66.01933791111111,
        "median": 65.633209,
        "standard_deviation": 6.01107851182672,
        "coefficient_of_variation": 0.09105026954254036,
        "min": 48.614292,
        "max": 97.132125,
        "range": 48.517833
    },
    "total_camera_idle_time_ms": {
        "mean": 0.47761024444444444,
        "median": 0.214709,
        "standard_deviation": 1.5390305220249556,
        "coefficient_of_variation": 3.2223565970934183,
        "min": 0.1345,
        "max": 10.634916,
        "range": 10.500416000000001
    }
}
```

the development branch is currently behind main, so I'm pulling into main directly.